### PR TITLE
Add container for digest layout

### DIFF
--- a/digest.html
+++ b/digest.html
@@ -10,6 +10,11 @@
         background-color: #fff;
         margin: 20px;
     }
+    .container {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+    }
     .card {
         background-color: #f9f9f9;
         border: 1px solid #eee;
@@ -24,7 +29,7 @@
         text-decoration: none;
     }
     .summary {
-        font-size: 14px;
+        font-size: 16px;
         color: #333;
         margin: 10px 0;
         line-height: 1.6;
@@ -41,6 +46,7 @@
     </style>
 </head>
 <body>
+<div class="container">
 <h1>Polaris 每日 AI 與 Fintech 新聞摘要 — 2025-06-12</h1>
 <p>由 Polaris 系統生成 ┃ 揭露最新的 AI 與 Fintech 動向</p>
 
@@ -89,5 +95,6 @@
 </div>
 
 
+</div>
 </body>
 </html>

--- a/generate_digest.py
+++ b/generate_digest.py
@@ -15,6 +15,11 @@ TEMPLATE = """
         background-color: #fff;
         margin: 20px;
     }
+    .container {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+    }
     .card {
         background-color: #f9f9f9;
         border: 1px solid #eee;
@@ -29,7 +34,7 @@ TEMPLATE = """
         text-decoration: none;
     }
     .summary {
-        font-size: 14px;
+        font-size: 16px;
         color: #333;
         margin: 10px 0;
         line-height: 1.6;
@@ -46,6 +51,7 @@ TEMPLATE = """
     </style>
 </head>
 <body>
+<div class="container">
 <h1>Polaris 每日 AI 與 Fintech 新聞摘要 — {{ date }}</h1>
 <p>由 Polaris 系統生成 ┃ 揭露最新的 AI 與 Fintech 動向</p>
 {% for category, articles in grouped.items() %}
@@ -64,6 +70,7 @@ TEMPLATE = """
 </div>
 {% endfor %}
 {% endfor %}
+</div>
 </body>
 </html>
 """


### PR DESCRIPTION
## Summary
- wrap digest content in a `.container` for centered layout and limited width
- bump summary font size for better readability
- update `generate_digest.py` template to use new container style

## Testing
- `python3 generate_digest.py sample_articles.json`

------
https://chatgpt.com/codex/tasks/task_e_684a9081e5fc832792c2429a19872580