### PR TITLE
Refine digest color scheme

### DIFF
--- a/digest.html
+++ b/digest.html
@@ -8,8 +8,8 @@
     @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
     body {
         font-family: Arial, sans-serif;
-        background-color: #fdf6e3;
-        color: #3b2f2f;
+        background-color: #f2f1ee;  /* Grayer cream */
+        color: #2b211d;             /* Deep Oxford Brown */
         margin: 20px;
     }
     .container {
@@ -21,7 +21,7 @@
         font-family: 'Playfair Display', serif;
         font-size: 28px;
         font-weight: 700;
-        color: #3b2f2f;
+        color: #2b211d;             /* Deep Oxford Brown */
         margin-bottom: 10px;
     }
     .card {
@@ -34,29 +34,29 @@
     .title a {
         font-size: 16px;
         font-weight: bold;
-        color: #6e2f3c;
+        color: #5c2c35;             /* Dusty Burgundy */
         text-decoration: none;
     }
 
     .title a:hover {
         text-decoration: underline;
-        color: #3b2f2f;
+        color: #2b211d;             /* Hover: back to Oxford Brown */
     }
     .summary {
         font-size: 16px;
-        color: #3b2f2f;
+        color: #2b211d;             /* Match all text */
         margin: 10px 0;
         line-height: 1.6;
     }
     .source {
         font-size: 12px;
-        color: #3b2f2f;
+        color: #5c2c35;             /* Burgundy accent for source line */
     }
     .category-title {
         font-size: 18px;
         font-weight: bold;
         margin: 30px 0 10px;
-        color: #3b2f2f;
+        color: #2b211d;             /* Deep Oxford Brown */
     }
     </style>
 </head>

--- a/generate_digest.py
+++ b/generate_digest.py
@@ -13,8 +13,8 @@ TEMPLATE = """
     @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
     body {
         font-family: Arial, sans-serif;
-        background-color: #fdf6e3;
-        color: #3b2f2f;
+        background-color: #f2f1ee;  /* Grayer cream */
+        color: #2b211d;             /* Deep Oxford Brown */
         margin: 20px;
     }
     .container {
@@ -26,7 +26,7 @@ TEMPLATE = """
         font-family: 'Playfair Display', serif;
         font-size: 28px;
         font-weight: 700;
-        color: #3b2f2f;
+        color: #2b211d;             /* Deep Oxford Brown */
         margin-bottom: 10px;
     }
     .card {
@@ -39,29 +39,29 @@ TEMPLATE = """
     .title a {
         font-size: 16px;
         font-weight: bold;
-        color: #6e2f3c;
+        color: #5c2c35;             /* Dusty Burgundy */
         text-decoration: none;
     }
 
     .title a:hover {
         text-decoration: underline;
-        color: #3b2f2f;
+        color: #2b211d;             /* Hover: back to Oxford Brown */
     }
     .summary {
         font-size: 16px;
-        color: #3b2f2f;
+        color: #2b211d;             /* Match all text */
         margin: 10px 0;
         line-height: 1.6;
     }
     .source {
         font-size: 12px;
-        color: #3b2f2f;
+        color: #5c2c35;             /* Burgundy accent for source line */
     }
     .category-title {
         font-size: 18px;
         font-weight: bold;
         margin: 30px 0 10px;
-        color: #3b2f2f;
+        color: #2b211d;             /* Deep Oxford Brown */
     }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- adjust CSS colors to muted brown and grayer cream
- regenerate digest with new style

## Testing
- `python3 generate_digest.py`

------
https://chatgpt.com/codex/tasks/task_e_684a9b0316e48327b38fdc8163c10100