### PR TITLE
Add email sending script using yagmail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jinja2
+yagmail

--- a/send_digest.py
+++ b/send_digest.py
@@ -1,0 +1,18 @@
+import yagmail
+from datetime import datetime
+
+SENDER = "chenkuan.wu@tpisoftware.com"
+PASSWORD = "chenkuan0330!"  # TODO: move to env var
+RECIPIENT = "kuan940330@gmail.com"
+
+def main():
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    subject = f"📬 Polaris Daily Digest – {date_str}"
+    with open('digest.html', 'r', encoding='utf-8') as f:
+        html_content = f.read()
+    yag = yagmail.SMTP(SENDER, PASSWORD)
+    yag.send(to=RECIPIENT, subject=subject, contents=html_content)
+    print("\u2705 Email sent.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add new send_digest.py script to email digest.html via Gmail
- install yagmail dependency in requirements.txt

## Testing
- `python -m py_compile send_digest.py`
- `python send_digest.py` *(fails: OSError [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f15739483278bd95c23839e69fa