### PR TITLE
Refactor send_digest to generate HTML via template

### DIFF
--- a/send_digest.py
+++ b/send_digest.py
@@ -1,15 +1,25 @@
 import yagmail
 from datetime import datetime
+from generate_digest import load_articles, generate_html
 
 SENDER = "chenkuan.wu@tpisoftware.com"
 PASSWORD = "chenkuan0330!"  # TODO: move to env var
 RECIPIENT = "kuan940330@gmail.com"
 
+JSON_PATH = "sample_articles.json"
+
+
 def main():
-    date_str = datetime.now().strftime('%Y-%m-%d')
+    """Generate the digest HTML and email it."""
+    # Use the generator from ``generate_digest.py`` which already defines a
+    # clean multiline HTML template. This avoids inserting ``<br>`` tags in the
+    # ``<style>`` block and keeps the CSS valid for email clients.
+    articles = load_articles(JSON_PATH)
+    html_content = generate_html(articles)
+
+    date_str = datetime.now().strftime("%Y-%m-%d")
     subject = f"📬 Polaris Daily Digest – {date_str}"
-    with open('digest.html', 'r', encoding='utf-8') as f:
-        html_content = f.read()
+
     yag = yagmail.SMTP(SENDER, PASSWORD)
     yag.send(to=RECIPIENT, subject=subject, contents=html_content)
     print("\u2705 Email sent.")


### PR DESCRIPTION
## Summary
- load articles and generate HTML from `generate_digest` instead of reading file
- keep CSS clean via template to avoid `<br>` tokens in `<style>`

## Testing
- `python3 generate_digest.py sample_articles.json`
- `python3 send_digest.py` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684aa452740083279644e736f01081bc