### PR TITLE
Fix CSS font import

### DIFF
--- a/digest.html
+++ b/digest.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <title>📬 Polaris Daily Digest – 2025-06-12</title>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
     <style>
-    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
     body {
         font-family: Arial, sans-serif;
         background-color: #f2f1ee;  /* Grayer cream */

--- a/generate_digest.py
+++ b/generate_digest.py
@@ -9,8 +9,8 @@ TEMPLATE = """
 <head>
     <meta charset="UTF-8">
     <title>📬 Polaris Daily Digest – {{ date }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
     <style>
-    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
     body {
         font-family: Arial, sans-serif;
         background-color: #f2f1ee;  /* Grayer cream */


### PR DESCRIPTION
## Summary
- fix Google font reference by using `<link>` tag instead of `@import`

## Testing
- `python3 -m py_compile generate_digest.py send_digest.py`
- `python3 generate_digest.py`

------
https://chatgpt.com/codex/tasks/task_e_684aa72b5698832784306e0344e756c1