### PR TITLE
Fix HTML email formatting

### DIFF
--- a/send_digest.py
+++ b/send_digest.py
@@ -1,4 +1,5 @@
-import yagmail
+import smtplib
+from email.message import EmailMessage
 from datetime import datetime
 from generate_digest import load_articles, generate_html
 
@@ -20,8 +21,16 @@ def main():
     date_str = datetime.now().strftime("%Y-%m-%d")
     subject = f"📬 Polaris Daily Digest – {date_str}"
 
-    yag = yagmail.SMTP(SENDER, PASSWORD)
-    yag.send(to=RECIPIENT, subject=subject, contents=html_content)
+    msg = EmailMessage()
+    msg['Subject'] = subject
+    msg['From'] = SENDER
+    msg['To'] = RECIPIENT
+    msg.set_content('This email requires an HTML capable client.')
+    msg.add_alternative(html_content, subtype='html')
+
+    with smtplib.SMTP_SSL('smtp.gmail.com', 465) as smtp:
+        smtp.login(SENDER, PASSWORD)
+        smtp.send_message(msg)
     print("\u2705 Email sent.")
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- avoid Yagmail automatic HTML modifications by using `smtplib`
- send the generated digest HTML without altering line breaks

## Testing
- `python -m py_compile generate_digest.py send_digest.py`
- `python generate_digest.py sample_articles.json`
- `python send_digest.py` *(fails: OSError: [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684aaae9f120832794e83016fd35961b