### PR TITLE
Switch to single-column digest layout

### DIFF
--- a/generate_digest.py
+++ b/generate_digest.py
@@ -3,18 +3,8 @@ import sys
 from datetime import datetime
 from jinja2 import Template
 
-TEMPLATE_FILE = "digest_two_column.html"
+TEMPLATE_FILE = "templates/digest_single_column.html"
 
-CATEGORIES = [
-    "General Tech & Startups",
-    "Applied AI & Fintech",
-    "Blockchain & Crypto",
-]
-EMOJIS = {
-    "General Tech & Startups": "📱",
-    "Applied AI & Fintech": "💳",
-    "Blockchain & Crypto": "🪙",
-}
 REGIONS = ["East Asia", "Global"]
 
 def load_articles(path: str):
@@ -22,20 +12,31 @@ def load_articles(path: str):
         return json.load(f)
 
 def group_articles_by_region(articles):
-    grouped = {r: {c: [] for c in CATEGORIES} for r in REGIONS}
+    """Return lists of articles for each region."""
+    grouped = {r: [] for r in REGIONS}
     for article in articles:
-        region = article.get('region', 'Global')
-        category = article.get('category')
-        if region in grouped and category in grouped[region]:
-            grouped[region][category].append(article)
+        region = article.get("region", "Global")
+        if region not in grouped:
+            region = "Global"
+        grouped[region].append(article)
     return grouped
 
 def generate_html(articles):
     grouped = group_articles_by_region(articles)
-    with open(TEMPLATE_FILE, 'r', encoding='utf-8') as f:
+    global_articles = grouped.get("Global", [])
+    east_asian_articles = grouped.get("East Asia", [])
+
+    for article in global_articles + east_asian_articles:
+        if "published_at" not in article:
+            article["published_at"] = article.get("read_time", "")
+    with open(TEMPLATE_FILE, "r", encoding="utf-8") as f:
         template = Template(f.read())
-    date_str = datetime.now().strftime('%Y-%m-%d')
-    return template.render(date=date_str, grouped=grouped, emoji=EMOJIS)
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    return template.render(
+        date=date_str,
+        global_articles=global_articles,
+        east_asian_articles=east_asian_articles,
+    )
 
 def main():
     if len(sys.argv) > 1:

--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -1,0 +1,51 @@
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial, sans-serif; max-width:600px; margin:auto;">
+  <!-- \ud83c\udf0d Global Section -->
+  <tr>
+    <td style="padding: 24px;">
+      <h2 style="font-size: 20px; margin-bottom: 12px;">\ud83c\udf0d Global</h2>
+      {% for article in global_articles %}
+        <div style="margin-bottom: 24px;">
+          <a href="{{ article.url }}" style="color:#000; text-decoration:none; font-weight:bold; font-size: 16px;">
+            {{ article.title }}
+          </a>
+          <p style="font-size: 14px; line-height: 1.6;">{{ article.summary }}</p>
+          <div style="font-size: 12px; color: #888;">{{ article.source }} \u2503 {{ article.published_at }}</div>
+          {% if article.tags %}
+            <div style="margin-top: 6px;">
+              {% for tag in article.tags %}
+                <span style="display: inline-block; background: #f0f0f0; font-size: 11px; border-radius: 999px; padding: 4px 10px; margin-right: 6px;">
+                  {{ tag }}
+                </span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </td>
+  </tr>
+
+  <!-- \ud83c\udf0f East Asia Section -->
+  <tr>
+    <td style="padding: 24px;">
+      <h2 style="font-size: 20px; margin-bottom: 12px;">\ud83c\udf0f East Asia</h2>
+      {% for article in east_asian_articles %}
+        <div style="margin-bottom: 24px;">
+          <a href="{{ article.url }}" style="color:#000; text-decoration:none; font-weight:bold; font-size: 16px;">
+            {{ article.title }}
+          </a>
+          <p style="font-size: 14px; line-height: 1.6;">{{ article.summary }}</p>
+          <div style="font-size: 12px; color: #888;">{{ article.source }} \u2503 {{ article.published_at }}</div>
+          {% if article.tags %}
+            <div style="margin-top: 6px;">
+              {% for tag in article.tags %}
+                <span style="display: inline-block; background: #f0f0f0; font-size: 11px; border-radius: 999px; padding: 4px 10px; margin-right: 6px;">
+                  {{ tag }}
+                </span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## Summary
- add new `digest_single_column.html` template under `templates/`
- update `generate_digest.py` to produce single-column HTML output and handle missing `published_at`

## Testing
- `python3 generate_digest.py news_data.json`

------
https://chatgpt.com/codex/tasks/task_e_684ba3993cb48327bbbf81469ce6fa93