### PR TITLE
Fix digest single-column layout

### DIFF
--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -11,21 +11,23 @@
   <title>📬 Polaris Daily Digest – {{ date }}</title>
 </head>
 <body style="font-family:Arial, sans-serif; background-color:#f2f1ee; color:#2b211d; margin:20px;">
-  <div style="max-width:600px;margin:auto;padding:24px;">
-    <!-- \ud83c\udf0d Global Section -->
-    <h1 style="font-size:22px;font-weight:bold;margin-bottom:12px;">\ud83c\udf0d Global</h1>
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family: Arial, sans-serif; max-width: 720px; margin: auto;">
+  <tr>
+    <td style="padding: 24px;">
+    <!-- 🌍 Global Section -->
+    <h2>🌍 Global</h2>
     {% for category, articles in global_articles|groupby('category') %}
-      <h2 style="font-size:18px;font-weight:bold;margin-top:40px;display:flex;align-items:center;">
-        <span style="font-size:20px;margin-right:6px;">{{ icons.get(category, '') }}</span>{{ category }}
+      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+        {{ icons.get(category, '') }} {{ category }}
       </h2>
       {% for article in articles %}
-        <div style="background:#f9f9f9;padding:18px;border-radius:12px;margin-bottom:24px;">
-          <a href="{{ article.url }}" style="text-decoration:none;color:#6a1b9a;font-weight:bold;font-size:16px;">{{ article.title }}</a>
+        <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
+          <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">{{ article.title }}</a>
           <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary }}</p>
           {% if article.tags %}
-            <div style="margin-top:8px;">
+            <div style="margin-top: 8px;">
               {% for tag in article.tags %}
-                <span style="display:inline-block;background:#eaeaea;color:#333;font-size:11px;padding:4px 10px;border-radius:999px;margin-right:5px;">{{ tag }}</span>
+                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
               {% endfor %}
             </div>
           {% endif %}
@@ -34,20 +36,20 @@
       {% endfor %}
     {% endfor %}
 
-    <!-- \ud83c\udf0f East Asia Section -->
-    <h1 style="font-size:22px;font-weight:bold;margin-bottom:12px;">\ud83c\udf0f East Asia</h1>
+    <!-- 🌏 East Asia Section -->
+    <h2>🌏 East Asia</h2>
     {% for category, articles in east_asian_articles|groupby('category') %}
-      <h2 style="font-size:18px;font-weight:bold;margin-top:40px;display:flex;align-items:center;">
-        <span style="font-size:20px;margin-right:6px;">{{ icons.get(category, '') }}</span>{{ category }}
+      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+        {{ icons.get(category, '') }} {{ category }}
       </h2>
       {% for article in articles %}
-        <div style="background:#f9f9f9;padding:18px;border-radius:12px;margin-bottom:24px;">
-          <a href="{{ article.url }}" style="text-decoration:none;color:#6a1b9a;font-weight:bold;font-size:16px;">{{ article.title }}</a>
+        <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
+          <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">{{ article.title }}</a>
           <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary }}</p>
           {% if article.tags %}
-            <div style="margin-top:8px;">
+            <div style="margin-top: 8px;">
               {% for tag in article.tags %}
-                <span style="display:inline-block;background:#eaeaea;color:#333;font-size:11px;padding:4px 10px;border-radius:999px;margin-right:5px;">{{ tag }}</span>
+                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
               {% endfor %}
             </div>
           {% endif %}
@@ -55,6 +57,8 @@
         </div>
       {% endfor %}
     {% endfor %}
-  </div>
+        </td>
+    </tr>
+  </table>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix emoji header characters and unify header style
- keep visited links black and bold
- adjust section header markup and article spacing
- display article tags and center layout using a table

## Testing
- `pip install -r requirements.txt`
- `python generate_digest.py`

------
https://chatgpt.com/codex/tasks/task_e_684bac2a73c88327af7f96e1b2ef57ce