### PR TITLE
Update fonts to Playfair Display and Inter

### DIFF
--- a/digest.html
+++ b/digest.html
@@ -6,116 +6,116 @@
   <meta charset="UTF-8">
   <title>📬 Polaris Daily Digest – 2025-06-13</title>
 </head>
-<body style="font-family:Arial, sans-serif; background-color:#f2f1ee; color:#2b211d; margin:0;">
-  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family: Arial, sans-serif; max-width: 720px; margin:0 auto;">
+<body style="font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; background-color:#f2f1ee; color:#2b211d; margin:0;">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; max-width: 720px; margin:0 auto;">
   <tr>
     <td style="padding: 16px;">
     <!-- 🌍 Global Section -->
-    <h2>🌍 Global</h2>
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌍 Global</h2>
     
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         💳 Applied AI & Fintech
       </h2>
       
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="https://theverge.com/stripe-ai-fraud-detection" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">Stripe 推出新 AI 風控系統</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">Stripe 近期推出一套基於機器學習的新型詐騙偵測系統，旨在提升金融交易的安全性。該系統可在交易過程中即時分析行為數據，並透過其訓練的 LLM 模型預測異常模式，提前標記可能的詐騙事件。Stripe 表示，這套系統的準確率超過 96%，能夠大幅降低誤判率與用戶流失率。新功能已與 Stripe 的 API 服務整合，現階段已於歐美數千家企業中測試部署，未來將向亞洲市場擴展。</p>
+          <a href="https://theverge.com/stripe-ai-fraud-detection" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">Stripe 推出新 AI 風控系統</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">Stripe 近期推出一套基於機器學習的新型詐騙偵測系統，旨在提升金融交易的安全性。該系統可在交易過程中即時分析行為數據，並透過其訓練的 LLM 模型預測異常模式，提前標記可能的詐騙事件。Stripe 表示，這套系統的準確率超過 96%，能夠大幅降低誤判率與用戶流失率。新功能已與 Stripe 的 API 服務整合，現階段已於歐美數千家企業中測試部署，未來將向亞洲市場擴展。</p>
           
-          <div style="font-size:12px;color:#999;margin-top:6px;">The Verge \u2503 4 分鐘閱讀</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">The Verge \u2503 4 分鐘閱讀</div>
         </div>
       
     
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         🪙 Blockchain & Crypto
       </h2>
       
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="https://coindesk.com/2025/06/11/ethereum-cancun-upgrade" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">以太坊升級帶來更快的交易速度</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">以太坊核心開發者宣布，名為 Cancun-Deneb 的重大升級進入測試階段，該升級將透過 Proto-Danksharding 技術改善 Layer 2（L2）交易的效率與成本。Proto-Danksharding 可顯著降低數據儲存負擔，讓 Arbitrum、Optimism 等 L2 網路手續費降低 40%–60%。開發團隊預計正式升級將於 2025 年第三季上線，這對於推動 DeFi 應用普及與降低用戶進入門檻具有關鍵意義。社群普遍看好此升級將是 Web3 發展的重要里程碑。</p>
+          <a href="https://coindesk.com/2025/06/11/ethereum-cancun-upgrade" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">以太坊升級帶來更快的交易速度</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">以太坊核心開發者宣布，名為 Cancun-Deneb 的重大升級進入測試階段，該升級將透過 Proto-Danksharding 技術改善 Layer 2（L2）交易的效率與成本。Proto-Danksharding 可顯著降低數據儲存負擔，讓 Arbitrum、Optimism 等 L2 網路手續費降低 40%–60%。開發團隊預計正式升級將於 2025 年第三季上線，這對於推動 DeFi 應用普及與降低用戶進入門檻具有關鍵意義。社群普遍看好此升級將是 Web3 發展的重要里程碑。</p>
           
-          <div style="font-size:12px;color:#999;margin-top:6px;">CoinDesk \u2503 5 分鐘閱讀</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">CoinDesk \u2503 5 分鐘閱讀</div>
         </div>
       
     
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         📱 General Tech & Startups
       </h2>
       
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="https://techcrunch.com/2025/06/11/can-scale-ai-and-alexandr-wang-reignite-metas-ai-efforts/" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">Meta 與 Scale AI 合作重啟 AI 戰略</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">Meta 宣布與新創公司 Scale AI 合作成立尖端 AI 實驗室，目標是打造下一代大型語言模型來與 OpenAI 的 GPT-5 競爭。此次合作由 Scale AI 創辦人 Alexandr Wang 領軍，將專注於訓練多模態模型，支援語音、圖像與文字處理。該團隊預計於 2025 年底前推出開放版本，作為 Meta 重新進軍 AI 領域的關鍵一步。業界普遍認為，此舉將改變目前由 OpenAI 和 Google 主導的模型格局，並帶動開源模型的創新競爭。</p>
+          <a href="https://techcrunch.com/2025/06/11/can-scale-ai-and-alexandr-wang-reignite-metas-ai-efforts/" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">Meta 與 Scale AI 合作重啟 AI 戰略</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">Meta 宣布與新創公司 Scale AI 合作成立尖端 AI 實驗室，目標是打造下一代大型語言模型來與 OpenAI 的 GPT-5 競爭。此次合作由 Scale AI 創辦人 Alexandr Wang 領軍，將專注於訓練多模態模型，支援語音、圖像與文字處理。該團隊預計於 2025 年底前推出開放版本，作為 Meta 重新進軍 AI 領域的關鍵一步。業界普遍認為，此舉將改變目前由 OpenAI 和 Google 主導的模型格局，並帶動開源模型的創新競爭。</p>
           
-          <div style="font-size:12px;color:#999;margin-top:6px;">TechCrunch \u2503 5 分鐘閱讀</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">TechCrunch \u2503 5 分鐘閱讀</div>
         </div>
       
     
 
     <!-- 🌏 East Asia Section -->
-    <h2>🌏 East Asia</h2>
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌏 East Asia</h2>
     
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         💳 Applied AI & Fintech
       </h2>
       
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="https://www.nikkei.com/article/ai-regulatory-platform" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">日本銀行導入 AI 即時監理平台</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">日本金融監管機構近日宣布測試導入全新 AI 即時監理平台，該系統可針對可疑金融交易進行即時監控，並主動預測潛在洗錢風險。此平台透過自然語言處理（NLP）與大數據模型進行風險分級，並可與銀行內部系統串接，自動回報異常行為。該項技術預計於 2026 年全面部署，成為日本金融監管數位化的重要里程碑。</p>
+          <a href="https://www.nikkei.com/article/ai-regulatory-platform" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">日本銀行導入 AI 即時監理平台</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">日本金融監管機構近日宣布測試導入全新 AI 即時監理平台，該系統可針對可疑金融交易進行即時監控，並主動預測潛在洗錢風險。此平台透過自然語言處理（NLP）與大數據模型進行風險分級，並可與銀行內部系統串接，自動回報異常行為。該項技術預計於 2026 年全面部署，成為日本金融監管數位化的重要里程碑。</p>
           
             <div style="margin-top: 8px;">
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">日本</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">日本</span>
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">AI</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">AI</span>
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Regulation</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Regulation</span>
               
             </div>
           
-          <div style="font-size:12px;color:#999;margin-top:6px;">日經新聞 \u2503 4 分鐘閱讀</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">日經新聞 \u2503 4 分鐘閱讀</div>
         </div>
       
     
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         🪙 Blockchain & Crypto
       </h2>
       
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="https://www.yna.co.kr/blockchain-new-regulation" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">韓國通過加密貨幣交易所監管新法案</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">韓國國會近期正式通過一項針對虛擬貨幣交易所的新監管法案，要求平台須遵守更嚴格的 KYC（用戶身份驗證）與資產隔離政策，確保用戶資產與平台營運資金完全分開。此法案也明定所有交易平台需向金融監管機構定期提交透明度報告，並建立即時監控機制以防止洗錢與詐騙。分析指出，這將大幅提升韓國在全球虛擬資產治理中的制度可信度。</p>
+          <a href="https://www.yna.co.kr/blockchain-new-regulation" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">韓國通過加密貨幣交易所監管新法案</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">韓國國會近期正式通過一項針對虛擬貨幣交易所的新監管法案，要求平台須遵守更嚴格的 KYC（用戶身份驗證）與資產隔離政策，確保用戶資產與平台營運資金完全分開。此法案也明定所有交易平台需向金融監管機構定期提交透明度報告，並建立即時監控機制以防止洗錢與詐騙。分析指出，這將大幅提升韓國在全球虛擬資產治理中的制度可信度。</p>
           
             <div style="margin-top: 8px;">
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">南韓</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">南韓</span>
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Regulation</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Regulation</span>
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">虛擬貨幣</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">虛擬貨幣</span>
               
             </div>
           
-          <div style="font-size:12px;color:#999;margin-top:6px;">韓聯社 \u2503 5 分鐘閱讀</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">韓聯社 \u2503 5 分鐘閱讀</div>
         </div>
       
     
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         📱 General Tech & Startups
       </h2>
       
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="https://techcrunch.com/2025/06/12/appworks-launches-200m-web3-fund" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">AppWorks 推出 2 億美元 Web3 基金</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">台灣知名創投加速器 AppWorks 宣布成立第三期早期創投基金，總規模高達 2 億美元，主要投資標的為 Web3 和人工智慧（AI）領域的新創公司。該基金將持續深耕東南亞與台灣市場，預計將扶植超過 50 間具備前瞻性技術的創新團隊，並協助其拓展海外市場。AppWorks 表示，此基金將成為推動區域創新與產業數位轉型的關鍵動力之一。</p>
+          <a href="https://techcrunch.com/2025/06/12/appworks-launches-200m-web3-fund" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">AppWorks 推出 2 億美元 Web3 基金</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">台灣知名創投加速器 AppWorks 宣布成立第三期早期創投基金，總規模高達 2 億美元，主要投資標的為 Web3 和人工智慧（AI）領域的新創公司。該基金將持續深耕東南亞與台灣市場，預計將扶植超過 50 間具備前瞻性技術的創新團隊，並協助其拓展海外市場。AppWorks 表示，此基金將成為推動區域創新與產業數位轉型的關鍵動力之一。</p>
           
             <div style="margin-top: 8px;">
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">台灣</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">台灣</span>
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Startup</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Startup</span>
               
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Web3</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">Web3</span>
               
             </div>
           
-          <div style="font-size:12px;color:#999;margin-top:6px;">TechCrunch \u2503 4 分鐘閱讀</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">TechCrunch \u2503 4 分鐘閱讀</div>
         </div>
       
     

--- a/digest_two_column.html
+++ b/digest_two_column.html
@@ -5,70 +5,70 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>📬 Polaris Daily Digest – {{ date }}</title>
 </head>
-<body style="font-family: Arial, sans-serif; background-color:#f2f1ee; color:#2b211d; margin:20px;">
+<body style="font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; background-color:#f2f1ee; color:#2b211d; margin:20px;">
   <center>
     <table role="presentation" width="90%" style="max-width:1024px; margin:0 auto;" cellpadding="0" cellspacing="0">
       <tr>
         <td colspan="2" style="padding:24px 0;">
-          <h1 style="font-family: 'Playfair Display', serif; font-size:28px; font-weight:700; margin:0; color:#2b211d;">📬 Polaris Daily Digest – {{ date }}</h1>
+          <h1 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-size:28px; font-weight:600; margin:0; color:#2b211d;">📬 Polaris Daily Digest – {{ date }}</h1>
         </td>
       </tr>
       <tr>
         <td style="vertical-align:top; width:50%; padding:8px;">
-          <h2 style="font-size:20px; margin:0 0 10px 0; color:#2b211d;">🌏 East Asian</h2>
+          <h2 style="font-size:20px; margin:0 0 10px 0; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌏 East Asian</h2>
           {% for category, articles in grouped['East Asia'].items() %}
-            <div style="font-size:18px; font-weight:bold; margin:20px 0 10px; color:#2b211d;">{{ emoji[category] }} {{ category }}</div>
+            <div style="font-size:18px; font-weight:600; margin:20px 0 10px; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">{{ emoji[category] }} {{ category }}</div>
             {% for article in articles %}
               <table role="presentation" width="100%" style="background-color:#f9f9f9; border:1px solid #eee; border-radius:8px; padding:15px; margin-bottom:15px;" cellpadding="0" cellspacing="0">
                 <tr>
                   <td>
-                    <a href="{{ article.url }}" style="font-size:16px; font-weight:bold; color:#5c2c35; text-decoration:none;">{{ article.title }}</a>
+                    <a href="{{ article.url }}" style="font-size:16px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; color:#5c2c35; text-decoration:none;">{{ article.title }}</a>
                   </td>
                 </tr>
                 <tr>
-                  <td style="font-size:16px; color:#2b211d; margin-top:10px; line-height:1.6;">{{ article.summary }}</td>
+                  <td style="font-size:16px; color:#2b211d; margin-top:10px; line-height:1.6; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.summary }}</td>
                 </tr>
                 {% if article.tags %}
                 <tr>
                   <td style="padding-top:8px;">
                     {% for tag in article.tags %}
-                      <span style="font-size:12px; background-color:#f0f0f0; color:#333; padding:4px 10px; border-radius:999px; white-space:nowrap; margin-right:4px;">{{ tag }}</span>
+                      <span style="font-size:12px; background-color:#f0f0f0; color:#333; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding:4px 10px; border-radius:999px; white-space:nowrap; margin-right:4px;">{{ tag }}</span>
                     {% endfor %}
                   </td>
                 </tr>
                 {% endif %}
                 <tr>
-                  <td style="font-size:12px; color:#5c2c35;">{{ article.source }} ┃ {{ article.read_time }}</td>
+                  <td style="font-size:12px; color:#5c2c35; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.source }} ┃ {{ article.read_time }}</td>
                 </tr>
               </table>
             {% endfor %}
           {% endfor %}
         </td>
         <td style="vertical-align:top; width:50%; padding:8px;">
-          <h2 style="font-size:20px; margin:0 0 10px 0; color:#2b211d;">🌍 Global</h2>
+          <h2 style="font-size:20px; margin:0 0 10px 0; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌍 Global</h2>
           {% for category, articles in grouped['Global'].items() %}
-            <div style="font-size:18px; font-weight:bold; margin:20px 0 10px; color:#2b211d;">{{ emoji[category] }} {{ category }}</div>
+            <div style="font-size:18px; font-weight:600; margin:20px 0 10px; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">{{ emoji[category] }} {{ category }}</div>
             {% for article in articles %}
               <table role="presentation" width="100%" style="background-color:#f9f9f9; border:1px solid #eee; border-radius:8px; padding:15px; margin-bottom:15px;" cellpadding="0" cellspacing="0">
                 <tr>
                   <td>
-                    <a href="{{ article.url }}" style="font-size:16px; font-weight:bold; color:#5c2c35; text-decoration:none;">{{ article.title }}</a>
+                    <a href="{{ article.url }}" style="font-size:16px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; color:#5c2c35; text-decoration:none;">{{ article.title }}</a>
                   </td>
                 </tr>
                 <tr>
-                  <td style="font-size:16px; color:#2b211d; margin-top:10px; line-height:1.6;">{{ article.summary }}</td>
+                  <td style="font-size:16px; color:#2b211d; margin-top:10px; line-height:1.6; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.summary }}</td>
                 </tr>
                 {% if article.tags %}
                 <tr>
                   <td style="padding-top:8px;">
                     {% for tag in article.tags %}
-                      <span style="font-size:12px; background-color:#f0f0f0; color:#333; padding:4px 10px; border-radius:999px; white-space:nowrap; margin-right:4px;">{{ tag }}</span>
+                      <span style="font-size:12px; background-color:#f0f0f0; color:#333; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding:4px 10px; border-radius:999px; white-space:nowrap; margin-right:4px;">{{ tag }}</span>
                     {% endfor %}
                   </td>
                 </tr>
                 {% endif %}
                 <tr>
-                  <td style="font-size:12px; color:#5c2c35;">{{ article.source }} ┃ {{ article.read_time }}</td>
+                  <td style="font-size:12px; color:#5c2c35; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.source }} ┃ {{ article.read_time }}</td>
                 </tr>
               </table>
             {% endfor %}

--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -10,50 +10,50 @@
   <meta charset="UTF-8">
   <title>📬 Polaris Daily Digest – {{ date }}</title>
 </head>
-<body style="font-family:Arial, sans-serif; background-color:#f2f1ee; color:#2b211d; margin:0;">
-  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family: Arial, sans-serif; max-width: 720px; margin:0 auto;">
+<body style="font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; background-color:#f2f1ee; color:#2b211d; margin:0;">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; max-width: 720px; margin:0 auto;">
   <tr>
     <td style="padding: 16px;">
     <!-- 🌍 Global Section -->
-    <h2>🌍 Global</h2>
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌍 Global</h2>
     {% for category, articles in global_articles|groupby('category') %}
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         {{ icons.get(category, '') }} {{ category }}
       </h2>
       {% for article in articles %}
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">{{ article.title }}</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary }}</p>
+          <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">{{ article.title }}</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.summary }}</p>
           {% if article.tags %}
             <div style="margin-top: 8px;">
               {% for tag in article.tags %}
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
               {% endfor %}
             </div>
           {% endif %}
-          <div style="font-size:12px;color:#999;margin-top:6px;">{{ article.source }} \u2503 {{ article.published_at or article.read_time }}</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.source }} \u2503 {{ article.published_at or article.read_time }}</div>
         </div>
       {% endfor %}
     {% endfor %}
 
     <!-- 🌏 East Asia Section -->
-    <h2>🌏 East Asia</h2>
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌏 East Asia</h2>
     {% for category, articles in east_asian_articles|groupby('category') %}
-      <h2 style="font-size: 18px; font-weight: bold; margin-top: 40px;">
+      <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         {{ icons.get(category, '') }} {{ category }}
       </h2>
       {% for article in articles %}
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
-          <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-weight: bold; font-size: 16px;">{{ article.title }}</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary }}</p>
+          <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">{{ article.title }}</a>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.summary }}</p>
           {% if article.tags %}
             <div style="margin-top: 8px;">
               {% for tag in article.tags %}
-                <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
+                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
               {% endfor %}
             </div>
           {% endif %}
-          <div style="font-size:12px;color:#999;margin-top:6px;">{{ article.source }} \u2503 {{ article.published_at or article.read_time }}</div>
+          <div style="font-size:12px;color:#999;margin-top:6px;font-family:'Inter', 'Georgia', 'Arial', 'Verdana', sans-serif; font-weight:400;">{{ article.source }} \u2503 {{ article.published_at or article.read_time }}</div>
         </div>
       {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Summary
- use Playfair Display for all headlines and article titles
- use Inter/Georgia font stack for body text

## Testing
- `python3 generate_digest.py news_data.json`
- `python3 -m py_compile generate_digest.py send_digest.py`


------
https://chatgpt.com/codex/tasks/task_e_684bbdc177a4832797f863eeac1de046