### PR TITLE
Improve layout of digest sections

### DIFF
--- a/digest.html
+++ b/digest.html
@@ -11,7 +11,8 @@
   <tr>
     <td style="padding: 16px;">
     <!-- 🌍 Global Section -->
-    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌍 Global</h2>
+    <div style="background-color:#f9f9f6; padding:16px; border-radius:8px; margin-bottom:20px;">
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size:24px; margin:0 0 10px 0;">🌍 Global</h2>
     
       <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         💳 Applied AI & Fintech
@@ -79,9 +80,11 @@
         </div>
       
     
+    </div>
 
     <!-- 🌏 East Asia Section -->
-    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌏 East Asia</h2>
+    <div style="background-color:#f4f4f9; padding:16px; border-radius:8px; margin-bottom:20px;">
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size:24px; margin:0 0 10px 0;">🌏 East Asia</h2>
     
       <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         💳 Applied AI & Fintech
@@ -149,6 +152,7 @@
         </div>
       
     
+    </div>
         </td>
     </tr>
   </table>

--- a/digest_two_column.html
+++ b/digest_two_column.html
@@ -14,8 +14,8 @@
         </td>
       </tr>
       <tr>
-        <td style="vertical-align:top; width:50%; padding:8px;">
-          <h2 style="font-size:20px; margin:0 0 10px 0; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌏 East Asian</h2>
+        <td style="vertical-align:top; width:50%; padding:8px; background-color:#f4f4f9;">
+          <h2 style="font-size:24px; margin:0 0 10px 0; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌏 East Asian</h2>
           {% for category, articles in grouped['East Asia'].items() %}
             <div style="font-size:18px; font-weight:600; margin:20px 0 10px; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">{{ emoji[category] }} {{ category }}</div>
             {% for article in articles %}
@@ -46,8 +46,8 @@
             {% endfor %}
           {% endfor %}
         </td>
-        <td style="vertical-align:top; width:50%; padding:8px;">
-          <h2 style="font-size:20px; margin:0 0 10px 0; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌍 Global</h2>
+        <td style="vertical-align:top; width:50%; padding:8px; background-color:#f9f9f6;">
+          <h2 style="font-size:24px; margin:0 0 10px 0; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌍 Global</h2>
           {% for category, articles in grouped['Global'].items() %}
             <div style="font-size:18px; font-weight:600; margin:20px 0 10px; color:#2b211d; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">{{ emoji[category] }} {{ category }}</div>
             {% for article in articles %}

--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -15,7 +15,8 @@
   <tr>
     <td style="padding: 16px;">
     <!-- 🌍 Global Section -->
-    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌍 Global</h2>
+    <div style="background-color:#f9f9f6; padding:16px; border-radius:8px; margin-bottom:20px;">
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size:24px; margin:0 0 10px 0;">🌍 Global</h2>
     {% for category, articles in global_articles|groupby('category') %}
       <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         {{ icons.get(category, '') }} {{ category }}
@@ -37,9 +38,11 @@
         </div>
       {% endfor %}
     {% endfor %}
+    </div>
 
     <!-- 🌏 East Asia Section -->
-    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600;">🌏 East Asia</h2>
+    <div style="background-color:#f4f4f9; padding:16px; border-radius:8px; margin-bottom:20px;">
+    <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size:24px; margin:0 0 10px 0;">🌏 East Asia</h2>
     {% for category, articles in east_asian_articles|groupby('category') %}
       <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         {{ icons.get(category, '') }} {{ category }}
@@ -61,6 +64,7 @@
         </div>
       {% endfor %}
     {% endfor %}
+    </div>
         </td>
     </tr>
   </table>


### PR DESCRIPTION
## Summary
- add background colors to Global and East Asian sections
- enlarge section headers for readability

## Testing
- `python -m py_compile generate_digest.py send_digest.py`
- `python generate_digest.py news_data.json`

------
https://chatgpt.com/codex/tasks/task_e_684bca433a1c83278631501e2b17cc77