### PR TITLE
Add news API fetcher

### DIFF
--- a/data/gnews_articles.json
+++ b/data/gnews_articles.json
@@ -1,0 +1,92 @@
+[
+  {
+    "title": "AI Mode is more in your face with this experimental Pixel Launcher change",
+    "description": "The Search bar inside the Pixel Launcher is a staple of the Android ecosystem and has been for a long while now, and while it has changed slightly over",
+    "url": "https://www.androidheadlines.com/2025/06/ai-mode-is-more-in-your-face-with-this-experimental-pixel-launcher-change.html",
+    "source": {
+      "name": "Android Headlines"
+    },
+    "publishedAt": "2025-06-12T21:23:59Z"
+  },
+  {
+    "title": "AI flunks logic test: Multiple studies reveal illusion of reasoning",
+    "description": "Apple researchers have uncovered a key weakness in today's most hyped AI systems – they falter at solving puzzles that require step-by-step reasoning. In a new paper,...",
+    "url": "https://www.techspot.com/news/108294-ai-flunks-logic-test-multiple-studies-reveal-illusion.html",
+    "source": {
+      "name": "TechSpot"
+    },
+    "publishedAt": "2025-06-12T21:17:00Z"
+  },
+  {
+    "title": "Volantis Unveils Photonic Compute Platform for the AI Era; Raises $9M in Seed Round With Alex Wang, Trevor Blackwell, and Others",
+    "description": "Press Release Volantis, a semiconductor startup building photonically integrated computers for the AI era, today emerged from stealth and announced a $9 million seed round of funding. The round includes backing from Alex Wang (Scale AI) and Trevor Blackwell (Y Combinator)….",
+    "url": "https://venturebeat.com/business/volantis-unveils-photonic-compute-platform-for-the-ai-era-raises-9m-in-seed-round-with-alex-wang-trevor-blackwell-and-others/",
+    "source": {
+      "name": "VentureBeat"
+    },
+    "publishedAt": "2025-06-12T15:25:51Z"
+  },
+  {
+    "title": "CADDi Strengthens Strategic Partnership With Google Cloud, Enters Google Cloud Marketplace",
+    "description": "Press Release CADDi, the AI-powered data platform transforming manufacturing by democratizing supply chain and design data, today announced its availability on the Google Cloud Marketplace. This significant milestone deepens CADDi’s existing strategic partnership with…",
+    "url": "https://venturebeat.com/business/caddi-strengthens-strategic-partnership-with-google-cloud-enters-google-cloud-marketplace/",
+    "source": {
+      "name": "VentureBeat"
+    },
+    "publishedAt": "2025-06-12T14:26:08Z"
+  },
+  {
+    "title": "Meta sues maker of Crush AI nudify app over Facebook and Instagram ads",
+    "description": "In the suit, which has been filed in the company's home of Hong Kong, Meta states that Crush AI made multiple attempts to circumvent Meta's ad review...",
+    "url": "https://www.techspot.com/news/108290-meta-sues-maker-crush-ai-nudify-app-over.html",
+    "source": {
+      "name": "TechSpot"
+    },
+    "publishedAt": "2025-06-12T13:49:00Z"
+  },
+  {
+    "title": "I used AI to cut my monthly expenses — here's how",
+    "description": "I asked AI to help me cut expenses, cancel sneaky subscriptions and meal plan smarter — here’s how I saved hundreds in just one month.",
+    "url": "https://www.tomsguide.com/ai/i-used-ai-to-cut-my-monthly-expenses-without-giving-up-the-things-i-love",
+    "source": {
+      "name": "Tom's Guide"
+    },
+    "publishedAt": "2025-06-12T12:00:00Z"
+  },
+  {
+    "title": "Samsung Galaxy Z Fold 7 teaser suggests a big AI camera upgrade is on the way",
+    "description": "Samsung's third teaser for its upcoming foldables suggests its cameras could be getting interesting AI powers.",
+    "url": "https://www.tomsguide.com/phones/samsung-phones/samsung-galaxy-z-fold-7-teaser-suggests-a-big-ai-camera-upgrade-is-on-the-way",
+    "source": {
+      "name": "Tom's Guide"
+    },
+    "publishedAt": "2025-06-12T11:15:56Z"
+  },
+  {
+    "title": "Rumored PlayStation handheld may share a key PS5 Pro feature",
+    "description": "A new PlayStation handheld is rumored, with a recent leak suggests it could feature an AMD APU, 16GB of DDR5 RAM, and the PS5 Pro's AI upscaling tech, PSSR.",
+    "url": "https://www.tomsguide.com/gaming/handheld-gaming/rumored-playstation-handheld-may-share-a-key-ps5-pro-feature-heres-what-we-know",
+    "source": {
+      "name": "Tom's Guide"
+    },
+    "publishedAt": "2025-06-12T11:06:45Z"
+  },
+  {
+    "title": "This AI Writing Detector Shows Its Work. For Me, It's a Step in the Right Direction",
+    "description": "Apps that purport to spot AI-generated text have a trust issue. The solution may be more transparency about what they find.",
+    "url": "https://www.cnet.com/tech/services-and-software/this-ai-writing-detector-shows-its-work-for-me-its-a-step-in-the-right-direction/",
+    "source": {
+      "name": "CNET"
+    },
+    "publishedAt": "2025-06-12T10:00:00Z"
+  },
+  {
+    "title": "WhatsApp is getting AI-powered summaries for unread chats",
+    "description": "WhatsApp is testing its own in-app, AI-powered feature that summarizes unread messages in chats, groups, and channels. Here’s how it works.",
+    "url": "https://9to5mac.com/2025/06/11/whatsapp-testing-ai-message-summaries/",
+    "source": {
+      "name": "9to5Mac"
+    },
+    "publishedAt": "2025-06-11T21:47:51Z"
+  }
+]

--- a/data/newsapi_articles.json
+++ b/data/newsapi_articles.json
@@ -1,0 +1,92 @@
+[
+  {
+    "title": "A profile of Airwallex co-founder Jack Zhang, who turned down Stripe's $1.2B offer seven years ago; the fintech is now valued at $6.2B and plans an IPO in 2026",
+    "description": "",
+    "url": "https://biztoc.com/x/ff0afb46bc526262",
+    "source": {
+      "name": "Biztoc.com"
+    },
+    "publishedAt": "2025-06-12T06:43:37Z"
+  },
+  {
+    "title": "Best Digital Media Stocks To Watch Now – June 10th",
+    "description": "Alibaba Group, Adobe, Digital Realty Trust, Sunrun, and Rocket Companies are the five Digital Media stocks to watch today, according to MarketBeat’s stock screener tool. Digital media stocks are shares of publicly traded companies that create, distribute or m…",
+    "url": "https://www.etfdailynews.com/2025/06/12/best-digital-media-stocks-to-watch-now-june-10th/",
+    "source": {
+      "name": "ETF Daily News"
+    },
+    "publishedAt": "2025-06-12T06:07:04Z"
+  },
+  {
+    "title": "Skeptical Science New Research for Week #24 2025",
+    "description": "Open access notables\nA Rapid Deterioration of the Transmissive Atmospheric Radiative Regime in the Western Arctic, Bertossa & L’Ecuyer, Geophysical Research Letters:\n\nThe tendency for the atmosphere to reside in one of two radiative states (“transmissive” or …",
+    "url": "https://skepticalscience.com/new_research_2025_24.html",
+    "source": {
+      "name": "Skepticalscience.com"
+    },
+    "publishedAt": "2025-06-12T06:06:29Z"
+  },
+  {
+    "title": "The Journey of Payments and Clearing Systems in India (Onkar Chachad)",
+    "description": "Ancient to Pre-Colonial Ages (Before 17th Century): The Dawn of Exchange In ancient India, rudimenta...",
+    "url": "https://www.finextra.com/blogposting/28669/the-journey-of-payments-and-clearing-systems-in-india",
+    "source": {
+      "name": "Finextra"
+    },
+    "publishedAt": "2025-06-12T05:27:04Z"
+  },
+  {
+    "title": "YeePay Showcases One-Stop Global Travel Payment Network at 2025 ITB China",
+    "description": "ITB China, Asia Pacific&#39;s most influential travel industry trade show, officially kicked off on May 27 at the Shanghai World Expo Exhibition &amp; ...",
+    "url": "https://en.antaranews.com/news/358977/yeepay-showcases-one-stop-global-travel-payment-network-at-2025-itb-china",
+    "source": {
+      "name": "Antaranews.com"
+    },
+    "publishedAt": "2025-06-12T05:22:54Z"
+  },
+  {
+    "title": "‘This latest generation of AI could change every job’: are fears of a slash and burn of white-collar roles well founded?",
+    "description": "Artificial intelligence is starting to have a profound effect on work and employment, though some believe much human labour will be disrupted rather than displaced",
+    "url": "https://www.irishtimes.com/business/2025/06/12/disrupted-or-displaced-how-ai-is-shaking-up-jobs/",
+    "source": {
+      "name": "The Irish Times"
+    },
+    "publishedAt": "2025-06-12T05:01:00Z"
+  },
+  {
+    "title": "RYOプロジェクト：穀物取引業界での初の実用事例とともにステーブルコイン「RYOPAY」を発表",
+    "description": "[Zenza Capital Pte. Limited]\n[画像: https://prcdn.freetls.fastly.net/release_image/158275/15/158275-15-3e9c6571afb36132d70e1f2b0e830e03-794x310.jpg?width=536&quality=85%2C75&format=jpeg&auto=webp&fit=bounds&amp...",
+    "url": "https://prtimes.jp/main/html/rd/p/000000015.000158275.html",
+    "source": {
+      "name": "Prtimes.jp"
+    },
+    "publishedAt": "2025-06-12T03:40:03Z"
+  },
+  {
+    "title": "Circle gains 10% on deals with Brazil’s Matera, Altman’s World",
+    "description": "Stablecoin issuer Circle Internet Group has gone live with USDC on Sam Altman’s World Chain and linked up with Brazil’s Matera to support multicurrency bank accounts.",
+    "url": "https://cointelegraph.com/news/circle-gains-matera-partnership-usdc-launch-on-world-chain",
+    "source": {
+      "name": "Cointelegraph"
+    },
+    "publishedAt": "2025-06-12T03:16:56Z"
+  },
+  {
+    "title": "Databricks says annualized revenue will reach $3.7 billion by next month",
+    "description": "Databricks told investors and analysts on Wednesday that annualized revenue will hit $3.7 billion by July, with 50% year-over-year growth.",
+    "url": "https://www.cnbc.com/2025/06/11/databricks-says-annualized-revenue-to-reach-3point7-billion-by-next-month.html",
+    "source": {
+      "name": "CNBC"
+    },
+    "publishedAt": "2025-06-12T01:46:01Z"
+  },
+  {
+    "title": "Payment aggregators under RBI lens; Pine Labs, Meesho’s IPO plans",
+    "description": "Happy Thursday! After approving about 54 companies to become payment aggregators, the central bank is tightening its reins in the sector. This and more in today’s ETtech Morning Dispatch.",
+    "url": "https://economictimes.indiatimes.com/tech/newsletters/morning-dispatch/payment-aggregators-under-rbi-lens-pine-labs-meeshos-ipo-plans/articleshow/121790318.cms",
+    "source": {
+      "name": "The Times of India"
+    },
+    "publishedAt": "2025-06-12T01:40:58Z"
+  }
+]

--- a/generate_articles.py
+++ b/generate_articles.py
@@ -1,0 +1,75 @@
+import json
+import requests
+
+NEWSAPI_KEY = "9d217822f10348cda2442c455e120ef2"
+GNEWS_KEY = "0e5e3a8d6f331bfdc614553393804bae"
+
+NEWSAPI_URL = "https://newsapi.org/v2/everything"
+GNEWS_URL = "https://gnews.io/api/v4/search"
+
+
+def fetch_newsapi():
+    params = {
+        "q": "AI Fintech",
+        "language": "en",
+        "pageSize": 10,
+        "sortBy": "publishedAt",
+        "apiKey": NEWSAPI_KEY,
+    }
+    response = requests.get(NEWSAPI_URL, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    articles = []
+    for a in data.get("articles", []):
+        articles.append(
+            {
+                "title": a.get("title"),
+                "description": a.get("description"),
+                "url": a.get("url"),
+                "source": {"name": a.get("source", {}).get("name")},
+                "publishedAt": a.get("publishedAt"),
+            }
+        )
+    return articles
+
+
+def fetch_gnews():
+    params = {
+        "q": "AI OR Fintech OR Crypto",
+        "lang": "en",
+        "country": "us",
+        "max": 10,
+        "apikey": GNEWS_KEY,
+    }
+    response = requests.get(GNEWS_URL, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    articles = []
+    for a in data.get("articles", []):
+        articles.append(
+            {
+                "title": a.get("title"),
+                "description": a.get("description"),
+                "url": a.get("url"),
+                "source": {"name": a.get("source", {}).get("name")},
+                "publishedAt": a.get("publishedAt"),
+            }
+        )
+    return articles
+
+
+def save_json(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def main():
+    newsapi_articles = fetch_newsapi()
+    save_json("data/newsapi_articles.json", newsapi_articles)
+
+    gnews_articles = fetch_gnews()
+    save_json("data/gnews_articles.json", gnews_articles)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 jinja2
 yagmail
+
+requests


### PR DESCRIPTION
## Summary
- add simple script to pull AI/Fintech/Crypto news from NewsAPI and GNews
- save fetched results in the `data` folder
- add `requests` to requirements

## Testing
- `pip install -r requirements.txt`
- `python generate_articles.py`

------
https://chatgpt.com/codex/tasks/task_e_684bc9409ee48327b250aa0c49bb4368