### PR TITLE
Implement news API fetch scripts

### DIFF
--- a/data/gnews_articles.json
+++ b/data/gnews_articles.json
@@ -1,0 +1,92 @@
+[
+  {
+    "title": "Top 10 Startup and Tech Funding News - June 9, 2025",
+    "description": "It’s Monday, June 9, 2025. Hope you had a great weekend. We’re back with your daily tech funding roundup, tracking where capital is flowing and which startups are laying the groundwork for what’s next. Today’s deals span AI coding assistants, fintech, cybersecurity, defense tech, biotech, climate innovation, and more. From Anysphere’s $900 million raise to",
+    "url": "https://techstartups.com/2025/06/09/top-10-startup-and-tech-funding-news-june-9-2025/",
+    "source": {
+      "name": "TechStartups.com"
+    },
+    "publishedAt": "2025-06-09T23:02:34Z"
+  },
+  {
+    "title": "Top 10 Startup and Tech Funding News for the Week Ending June 6, 2025",
+    "description": "It’s Friday, June 6, 2025—and we’re wrapping up the week with your daily tech funding snapshot, spotlighting where capital is flowing and which startups are gearing up for their next leap. Today’s lineup features a wide-ranging mix of startups spanning AI infrastructure, biotech, fintech, climate tech, and digital health. From Grammarly’s eye-popping $1 billion growth",
+    "url": "https://techstartups.com/2025/06/06/top-10-startup-and-tech-funding-news-for-the-week-ending-june-6-2025/",
+    "source": {
+      "name": "TechStartups.com"
+    },
+    "publishedAt": "2025-06-06T23:08:24Z"
+  },
+  {
+    "title": "Top tech startup funding news for today, May 21, 2025",
+    "description": "It’s May 21, 2025, and we’re back with your daily funding rundown—where the money’s going, who’s writing the checks, and which startups are making moves. From fintech and AI to sustainability and biotech, today’s batch covers a lot of ground. Some raised big, some stayed quiet on details, but all eyes are on what comes",
+    "url": "https://techstartups.com/2025/05/21/top-tech-startup-funding-news-for-today-may-21-2025/",
+    "source": {
+      "name": "TechStartups.com"
+    },
+    "publishedAt": "2025-05-21T22:01:38Z"
+  },
+  {
+    "title": "Klarna CEO says AI helped company shrink workforce by 40%",
+    "description": "The Swedish fintech provider has been outspoken about its aggressive adoption of AI tools across the company.",
+    "url": "https://www.cnbc.com/2025/05/14/klarna-ceo-says-ai-helped-company-shrink-workforce-by-40percent.html",
+    "source": {
+      "name": "CNBC"
+    },
+    "publishedAt": "2025-05-14T19:29:53Z"
+  },
+  {
+    "title": "Stripe unveils AI foundation model for payments, reveals ‘deeper partnership’ with Nvidia",
+    "description": "Fintech giant Stripe announced Wednesday a slew of new product launches at its annual Stripe Sessions user event. The highlights include a new AI",
+    "url": "https://techcrunch.com/2025/05/07/stripe-unveils-ai-foundation-model-for-payments-reveals-deeper-partnership-with-nvidia/",
+    "source": {
+      "name": "TechCrunch"
+    },
+    "publishedAt": "2025-05-07T21:31:20Z"
+  },
+  {
+    "title": "Four Ways AI Is Transforming Fintech",
+    "description": "Comparisons between AI and the early internet are unavoidable. So let’s get them out of the way: we’re fast approaching a time where apps without AI will seem as unthinkable as doing business without the internet. Right now, there’s lot of talk about fintechs adding AI to enhance core functionality within their consumer apps. In",
+    "url": "https://techstartups.com/2025/04/17/four-ways-ai-is-transforming-fintech/",
+    "source": {
+      "name": "TechStartups.com"
+    },
+    "publishedAt": "2025-04-17T21:19:01Z"
+  },
+  {
+    "title": "Fintech founder charged with fraud after 'AI' shopping app found to be powered by humans in the Philippines",
+    "description": "Albert Saniger, the founder and former CEO of Nate, an AI shopping app that promised a “universal” checkout experience, was charged with defrauding",
+    "url": "https://techcrunch.com/2025/04/10/fintech-founder-charged-with-fraud-after-ai-shopping-app-found-to-be-powered-by-humans-in-the-philippines/",
+    "source": {
+      "name": "TechCrunch"
+    },
+    "publishedAt": "2025-04-10T21:42:42Z"
+  },
+  {
+    "title": "A Chinese tech giant says it slashed AI costs using only Chinese chips",
+    "description": "Earlier this year, DeepSeek briefly crashed Nvidia’s stock because of speculation that its models require far fewer chips. Now, Chinese fintech giant Ant",
+    "url": "https://techcrunch.com/2025/03/24/a-chinese-tech-giant-says-it-slashed-ai-costs-using-only-chinese-chips/",
+    "source": {
+      "name": "TechCrunch"
+    },
+    "publishedAt": "2025-03-24T23:39:18Z"
+  },
+  {
+    "title": "VC Sheel Mohnot talks about Twitter fame, fintech, and the truth about AI startups",
+    "description": "If you follow fintech on X, it’s very likely that you have come across the account of Sheel Mohnot, co-founder and general partner of Better Tomorrow",
+    "url": "https://techcrunch.com/2025/02/12/vc-sheel-mohnot-talks-about-twitter-fame-fintech-and-the-truth-about-ai-startups/",
+    "source": {
+      "name": "TechCrunch"
+    },
+    "publishedAt": "2025-02-12T18:00:00Z"
+  },
+  {
+    "title": "Zest AI secures $200M growth funding from Insight Partners to advance AI-driven lending solutions",
+    "description": "Zest AI, a fintech startup revolutionizing lending with AI-driven solutions, announced today it has raised a $200 million growth investment from Insight Partners. This funding will support Zest AI's continued efforts to improve underwriting, fraud protection, and generative AI capabilities, with a focus on shaping the future of lending through innovative technology. Zest AI uses",
+    "url": "https://techstartups.com/2024/12/13/zest-ai-secures-200m-growth-funding-from-insight-partners-to-advance-ai-driven-lending-solutions/",
+    "source": {
+      "name": "TechStartups.com"
+    },
+    "publishedAt": "2024-12-13T14:49:21Z"
+  }
+]

--- a/data/newsapi_articles.json
+++ b/data/newsapi_articles.json
@@ -1,0 +1,92 @@
+[
+  {
+    "title": "India must exploit the full potential of collaborative lending",
+    "description": "Tie-ups between banks, non-bank lenders and digital platforms bring diverse strengths together for operations that can bridge India’s credit gaps. This ecosystem would do even better with a well designed framework for co-lending governance, data sharing and c…",
+    "url": "https://www.livemint.com/opinion/online-views/india-co-lending-models-nbfc-banking-digital-credit-fintech-ecosystem-financial-inclusion-api-rural-financing-digital-11749655498162.html",
+    "source": {
+      "name": "Livemint"
+    },
+    "publishedAt": "2025-06-12T07:00:00Z"
+  },
+  {
+    "title": "A profile of Airwallex co-founder Jack Zhang, who turned down Stripe's $1.2B offer seven years ago; the fintech is now valued at $6.2B and plans an IPO in 2026",
+    "description": "",
+    "url": "https://biztoc.com/x/ff0afb46bc526262",
+    "source": {
+      "name": "Biztoc.com"
+    },
+    "publishedAt": "2025-06-12T06:43:37Z"
+  },
+  {
+    "title": "Best Digital Media Stocks To Watch Now – June 10th",
+    "description": "Alibaba Group, Adobe, Digital Realty Trust, Sunrun, and Rocket Companies are the five Digital Media stocks to watch today, according to MarketBeat’s stock screener tool. Digital media stocks are shares of publicly traded companies that create, distribute or m…",
+    "url": "https://www.etfdailynews.com/2025/06/12/best-digital-media-stocks-to-watch-now-june-10th/",
+    "source": {
+      "name": "ETF Daily News"
+    },
+    "publishedAt": "2025-06-12T06:07:04Z"
+  },
+  {
+    "title": "Skeptical Science New Research for Week #24 2025",
+    "description": "Open access notables\nA Rapid Deterioration of the Transmissive Atmospheric Radiative Regime in the Western Arctic, Bertossa & L’Ecuyer, Geophysical Research Letters:\n\nThe tendency for the atmosphere to reside in one of two radiative states (“transmissive” or …",
+    "url": "https://skepticalscience.com/new_research_2025_24.html",
+    "source": {
+      "name": "Skepticalscience.com"
+    },
+    "publishedAt": "2025-06-12T06:06:29Z"
+  },
+  {
+    "title": "The Journey of Payments and Clearing Systems in India (Onkar Chachad)",
+    "description": "Ancient to Pre-Colonial Ages (Before 17th Century): The Dawn of Exchange In ancient India, rudimenta...",
+    "url": "https://www.finextra.com/blogposting/28669/the-journey-of-payments-and-clearing-systems-in-india",
+    "source": {
+      "name": "Finextra"
+    },
+    "publishedAt": "2025-06-12T05:27:04Z"
+  },
+  {
+    "title": "YeePay Showcases One-Stop Global Travel Payment Network at 2025 ITB China",
+    "description": "ITB China, Asia Pacific&#39;s most influential travel industry trade show, officially kicked off on May 27 at the Shanghai World Expo Exhibition &amp; ...",
+    "url": "https://en.antaranews.com/news/358977/yeepay-showcases-one-stop-global-travel-payment-network-at-2025-itb-china",
+    "source": {
+      "name": "Antaranews.com"
+    },
+    "publishedAt": "2025-06-12T05:22:54Z"
+  },
+  {
+    "title": "‘This latest generation of AI could change every job’: are fears of a slash and burn of white-collar roles well founded?",
+    "description": "Artificial intelligence is starting to have a profound effect on work and employment, though some believe much human labour will be disrupted rather than displaced",
+    "url": "https://www.irishtimes.com/business/2025/06/12/disrupted-or-displaced-how-ai-is-shaking-up-jobs/",
+    "source": {
+      "name": "The Irish Times"
+    },
+    "publishedAt": "2025-06-12T05:01:00Z"
+  },
+  {
+    "title": "RYOプロジェクト：穀物取引業界での初の実用事例とともにステーブルコイン「RYOPAY」を発表",
+    "description": "[Zenza Capital Pte. Limited]\n[画像: https://prcdn.freetls.fastly.net/release_image/158275/15/158275-15-3e9c6571afb36132d70e1f2b0e830e03-794x310.jpg?width=536&quality=85%2C75&format=jpeg&auto=webp&fit=bounds&amp...",
+    "url": "https://prtimes.jp/main/html/rd/p/000000015.000158275.html",
+    "source": {
+      "name": "Prtimes.jp"
+    },
+    "publishedAt": "2025-06-12T03:40:03Z"
+  },
+  {
+    "title": "Circle gains 10% on deals with Brazil’s Matera, Altman’s World",
+    "description": "Stablecoin issuer Circle Internet Group has gone live with USDC on Sam Altman’s World Chain and linked up with Brazil’s Matera to support multicurrency bank accounts.",
+    "url": "https://cointelegraph.com/news/circle-gains-matera-partnership-usdc-launch-on-world-chain",
+    "source": {
+      "name": "Cointelegraph"
+    },
+    "publishedAt": "2025-06-12T03:16:56Z"
+  },
+  {
+    "title": "Databricks says annualized revenue will reach $3.7 billion by next month",
+    "description": "Databricks told investors and analysts on Wednesday that annualized revenue will hit $3.7 billion by July, with 50% year-over-year growth.",
+    "url": "https://www.cnbc.com/2025/06/11/databricks-says-annualized-revenue-to-reach-3point7-billion-by-next-month.html",
+    "source": {
+      "name": "CNBC"
+    },
+    "publishedAt": "2025-06-12T01:46:01Z"
+  }
+]

--- a/generate_articles.py
+++ b/generate_articles.py
@@ -1,0 +1,75 @@
+import json
+import os
+from typing import List, Dict
+
+import requests
+
+NEWSAPI_KEY = "9d217822f10348cda2442c455e120ef2"
+GNEWS_KEY = "0e5e3a8d6f331bfdc614553393804bae"
+
+NEWSAPI_URL = (
+    "https://newsapi.org/v2/everything?q=AI%20Fintech&language=en&"
+    "pageSize=10&sortBy=publishedAt&apiKey=" + NEWSAPI_KEY
+)
+
+GNEWS_URL = (
+    "https://gnews.io/api/v4/search?q=AI%20Fintech&lang=en&country=us&max=10&apikey="
+    + GNEWS_KEY
+)
+
+DATA_DIR = "data"
+
+
+def fetch_newsapi_articles() -> List[Dict]:
+    resp = requests.get(NEWSAPI_URL, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    articles = []
+    for item in data.get("articles", []):
+        articles.append(
+            {
+                "title": item.get("title"),
+                "description": item.get("description"),
+                "url": item.get("url"),
+                "source": {"name": item.get("source", {}).get("name")},
+                "publishedAt": item.get("publishedAt"),
+            }
+        )
+    return articles
+
+
+def fetch_gnews_articles() -> List[Dict]:
+    resp = requests.get(GNEWS_URL, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    articles = []
+    for item in data.get("articles", []):
+        articles.append(
+            {
+                "title": item.get("title"),
+                "description": item.get("description"),
+                "url": item.get("url"),
+                "source": {"name": item.get("source", {}).get("name")},
+                "publishedAt": item.get("publishedAt"),
+            }
+        )
+    return articles
+
+
+def save_json(data: List[Dict], filename: str) -> None:
+    os.makedirs(DATA_DIR, exist_ok=True)
+    path = os.path.join(DATA_DIR, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def main():
+    newsapi_articles = fetch_newsapi_articles()
+    save_json(newsapi_articles, "newsapi_articles.json")
+
+    gnews_articles = fetch_gnews_articles()
+    save_json(gnews_articles, "gnews_articles.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jinja2
 yagmail
+requests


### PR DESCRIPTION
## Summary
- fetch AI & Fintech news from NewsAPI and GNews
- store results as JSON in the new data folder
- add `requests` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python generate_articles.py`

------
https://chatgpt.com/codex/tasks/task_e_684bcd55a6648327b7a48f6dc8b4137d