### PR TITLE
Implement test mode and NewsAPI.ai integration

### DIFF
--- a/generate_articles.py
+++ b/generate_articles.py
@@ -4,18 +4,27 @@ from typing import List, Dict
 
 import requests
 
+# Toggle this flag to ``False`` when running in production
+TEST_MODE = True
+
 NEWSAPI_KEY = "9d217822f10348cda2442c455e120ef2"
 GNEWS_KEY = "0e5e3a8d6f331bfdc614553393804bae"
+NEWSAPI_AI_KEY = "ef315c01-6412-4e85-b81e-8953cda71193"
+
+NUM_ARTICLES = 3 if TEST_MODE else 10
+NUM_AI_ARTICLES = 1 if TEST_MODE else 10
 
 NEWSAPI_URL = (
     "https://newsapi.org/v2/everything?q=AI%20Fintech&language=en&"
-    "pageSize=10&sortBy=publishedAt&apiKey=" + NEWSAPI_KEY
+    f"pageSize={NUM_ARTICLES}&sortBy=publishedAt&apiKey=" + NEWSAPI_KEY
 )
 
 GNEWS_URL = (
-    "https://gnews.io/api/v4/search?q=AI%20Fintech&lang=en&country=us&max=10&apikey="
-    + GNEWS_KEY
+    "https://gnews.io/api/v4/search?q=AI%20Fintech&lang=en&country=us&"
+    f"max={NUM_ARTICLES}&apikey=" + GNEWS_KEY
 )
+
+NEWSAPI_AI_URL = "https://eventregistry.org/api/v1/article/getArticles"
 
 DATA_DIR = "data"
 
@@ -56,6 +65,32 @@ def fetch_gnews_articles() -> List[Dict]:
     return articles
 
 
+def fetch_newsapi_ai_articles() -> List[Dict]:
+    params = {
+        "keyword": "AI Fintech",
+        "articlesPage": 1,
+        "articlesCount": NUM_AI_ARTICLES,
+        "resultType": "articles",
+        "lang": "eng",
+        "apiKey": NEWSAPI_AI_KEY,
+    }
+    resp = requests.get(NEWSAPI_AI_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    articles = []
+    for item in data.get("articles", {}).get("results", []):
+        articles.append(
+            {
+                "title": item.get("title"),
+                "content": item.get("body"),
+                "url": item.get("url"),
+                "source": {"name": item.get("source", {}).get("title")},
+                "publishedAt": item.get("date"),
+            }
+        )
+    return articles
+
+
 def save_json(data: List[Dict], filename: str) -> None:
     os.makedirs(DATA_DIR, exist_ok=True)
     path = os.path.join(DATA_DIR, filename)
@@ -65,10 +100,18 @@ def save_json(data: List[Dict], filename: str) -> None:
 
 def main():
     newsapi_articles = fetch_newsapi_articles()
-    save_json(newsapi_articles, "newsapi_articles.json")
+    newsapi_filename = "newsapi_articles_test.json" if TEST_MODE else "newsapi_articles.json"
+    save_json(newsapi_articles, newsapi_filename)
 
     gnews_articles = fetch_gnews_articles()
-    save_json(gnews_articles, "gnews_articles.json")
+    gnews_filename = "gnews_articles_test.json" if TEST_MODE else "gnews_articles.json"
+    save_json(gnews_articles, gnews_filename)
+
+    if TEST_MODE:
+        print("🔍 [Info] Skipping summarization for NewsAPI & GNews (test mode only)")
+
+    newsapi_ai_articles = fetch_newsapi_ai_articles()
+    save_json(newsapi_ai_articles, "newsapi_ai_articles.json")
 
 
 if __name__ == "__main__":

--- a/summarize_articles.py
+++ b/summarize_articles.py
@@ -1,0 +1,42 @@
+import json
+from typing import List, Dict
+
+INPUT_FILE = "data/newsapi_ai_articles.json"
+OUTPUT_FILE = "news_data.json"
+
+
+def load_articles() -> List[Dict]:
+    with open(INPUT_FILE, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def simple_summary(text: str, limit: int = 2) -> str:
+    """Return the first few sentences of the text as a crude summary."""
+    if not text:
+        return ""
+    sentences = text.split('. ')
+    return '. '.join(sentences[:limit]).strip()
+
+
+def main() -> None:
+    articles = load_articles()
+    summarized = []
+    for art in articles:
+        summary = simple_summary(art.get('content', ''))
+        summarized.append({
+            'region': 'Global',
+            'category': 'General Tech & Startups',
+            'title': art.get('title'),
+            'summary': summary,
+            'source': art.get('source', {}).get('name'),
+            'read_time': '1 min read',
+            'url': art.get('url'),
+            'tags': []
+        })
+    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+        json.dump(summarized, f, ensure_ascii=False, indent=2)
+    print(f"Wrote summaries to {OUTPUT_FILE}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add test mode controls and configurable article counts
- fetch NewsAPI.ai content for summarization
- skip summarization of NewsAPI and GNews when in test mode
- generate summaries from `newsapi_ai_articles.json`

## Testing
- `python -m py_compile generate_articles.py summarize_articles.py`
- `python generate_articles.py`
- `python summarize_articles.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd9209ed88327aeb8989664600a7d