### PR TITLE
Improve email error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# NewsRender
+
+This repository contains utilities for generating and sending a daily news digest.
+
+## Configuration
+
+Email credentials are loaded from environment variables using `python-dotenv`.
+Create a `.env` file in the project root containing:
+
+```
+DIGEST_SENDER=<your Gmail address>
+DIGEST_PASSWORD=<your Gmail app password>
+DIGEST_RECIPIENT=<recipient address>
+```
+
+Use a Gmail app password, which requires enabling two-factor authentication on your
+account. Refer to Google's documentation if authentication fails.
+
+## Usage
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Generate the HTML digest:
+
+   ```bash
+   python generate_digest.py
+   ```
+
+3. Send the digest via email:
+
+   ```bash
+   python send_digest.py
+   ```

--- a/send_digest.py
+++ b/send_digest.py
@@ -37,9 +37,15 @@ def main():
     msg.add_alternative(html_content, subtype='html')
 
     try:
-        with smtplib.SMTP_SSL('smtp.gmail.com', 465) as smtp:
+        with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:
             smtp.login(SENDER, PASSWORD)
             smtp.send_message(msg)
+    except smtplib.SMTPAuthenticationError as exc:
+        raise RuntimeError(
+            "Authentication failed. Ensure that the Gmail address and app "
+            "password are correct and that IMAP/SMTP access is enabled for "
+            "your account."
+        ) from exc
     except Exception as exc:
         raise RuntimeError(f"Failed to send email: {exc}") from exc
     print("\u2705 Email sent.")


### PR DESCRIPTION
## Summary
- improve Gmail authentication error message in `send_digest.py`
- document setup and usage in new README

## Testing
- `python send_digest.py` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684bf1e6f1108327a2695a9f5fd48b43