### PR TITLE
Use env vars for API keys and email credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ This repository contains utilities for generating and sending a daily news diges
 
 ## Configuration
 
-Email credentials are loaded from environment variables using `python-dotenv`.
+Credentials and API keys are loaded from environment variables using `python-dotenv`.
 Create a `.env` file in the project root containing:
 
 ```
 DIGEST_SENDER=<your Gmail address>
 DIGEST_PASSWORD=<your Gmail app password>
 DIGEST_RECIPIENT=<recipient address>
+OPENAI_API_KEY=<your OpenAI API key>
+NEWSAPI_AI_KEY=<your EventRegistry key>
 ```
 
 Use a Gmail app password, which requires enabling two-factor authentication on your

--- a/generate_articles.py
+++ b/generate_articles.py
@@ -3,10 +3,12 @@ import os
 from typing import List, Dict
 
 import requests
+from dotenv import load_dotenv
 
-# Hard coded API key for local testing. This avoids needing a .env file.
-# In production, consider loading this from an environment variable instead.
-NEWSAPI_AI_KEY = "ef315c01-6412-4e85-b81e-8953cda71193"
+load_dotenv()
+NEWSAPI_AI_KEY = os.getenv("NEWSAPI_AI_KEY")
+if not NEWSAPI_AI_KEY:
+    raise RuntimeError("Missing NEWSAPI_AI_KEY in environment")
 NEWSAPI_AI_URL = "https://eventregistry.org/api/v1/article/getArticles"
 
 # Fetch only one article per run to keep testing inexpensive

--- a/send_digest.py
+++ b/send_digest.py
@@ -1,12 +1,20 @@
+import os
 import smtplib
 from email.message import EmailMessage
 from datetime import datetime
+from dotenv import load_dotenv
 from generate_digest import load_articles, generate_html
 
-# ✅ 直接填入你的發件人資訊（不用 .env）
-SENDER = "chenkuan.wu@tpisoftware.com"
-PASSWORD = "dyuavxpiqnjtbljx"  # ← Gmail App 密碼（無空格）
-RECIPIENT = "chenkuan.wu@tpisoftware.com"
+# Load email credentials from environment variables
+load_dotenv()
+SENDER = os.getenv("DIGEST_SENDER")
+PASSWORD = os.getenv("DIGEST_PASSWORD")
+RECIPIENT = os.getenv("DIGEST_RECIPIENT")
+
+if not all([SENDER, PASSWORD, RECIPIENT]):
+    raise RuntimeError(
+        "Missing DIGEST_SENDER, DIGEST_PASSWORD or DIGEST_RECIPIENT in environment"
+    )
 
 # ✅ 正確的 JSON 檔案位置
 JSON_PATH = "data/news_data.json"

--- a/summarize_articles.py
+++ b/summarize_articles.py
@@ -1,13 +1,18 @@
 import json
+import os
 from typing import Dict, List, Tuple
 
 import openai
+from dotenv import load_dotenv
 
 INPUT_FILE = "data/newsapi_ai_articles.json"
 OUTPUT_FILE = "data/news_data.json"
 
-# TODO: Replace with loading from environment using os.getenv
-openai.api_key = "YOUR_OPENAI_API_KEY"
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+if not openai.api_key:
+    raise RuntimeError("Missing OPENAI_API_KEY in environment")
 
 
 def load_articles() -> List[Dict]:


### PR DESCRIPTION
## Summary
- load Gmail credentials from `.env`
- load OpenAI and EventRegistry keys from `.env`
- document required environment variables in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8904c13c83279dfaaef32f7d28de