### PR TITLE
Adjust summarization to Traditional Chinese only

### DIFF
--- a/data/news_data.json
+++ b/data/news_data.json
@@ -3,7 +3,6 @@
     "region": "Global",
     "category": "General Tech & Startups",
     "title": "Mirai School of Technology Is Changing Engineering in India - Here's How Students Are Learning AI from Day One",
-    "summary_en": "Mirai School of Technology (MSOT) in India is revolutionizing engineering education by integrating artificial intelligence from the first semester of its B.Tech program. Students engage in hands-on AI projects, guided by experienced professionals, and gain access to cutting-edge tools and labs. Graduates are well-prepared for careers in various high-tech fields, addressing India's growing demand for AI professionals.",
     "summary_zh": "Mirai科技學校在印度通過從學士學位課程的第一學期起融入人工智能，徹底改變了工程教育。學生在專業人士的指導下，參與實際的AI項目，並使用先進的工具和實驗室。畢業生為各個高科技領域的職業做好充分準備，應對印度對AI專業人才的不斷增長的需求。",
     "source": "Sri Lanka Source",
     "read_time": "1 min read",

--- a/digest.html
+++ b/digest.html
@@ -21,8 +21,7 @@
       
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
           <a href="https://www.srilankasource.com/news/278284163/mirai-school-of-technology-is-changing-engineering-in-india-here-how-students-are-learning-ai-from-day-one" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">Mirai School of Technology Is Changing Engineering in India - Here's How Students Are Learning AI from Day One</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;"><strong>EN:</strong> Mirai School of Technology (MSOT) in India is revolutionizing engineering education by integrating artificial intelligence from the first semester of its B.Tech program. Students engage in hands-on AI projects, guided by experienced professionals, and gain access to cutting-edge tools and labs. Graduates are well-prepared for careers in various high-tech fields, addressing India's growing demand for AI professionals.</p>
-          <p style="font-size:14px;line-height:1.6;margin-top:4px;"><strong>ZH:</strong> Mirai科技學校在印度通過從學士學位課程的第一學期起融入人工智能，徹底改變了工程教育。學生在專業人士的指導下，參與實際的AI項目，並使用先進的工具和實驗室。畢業生為各個高科技領域的職業做好充分準備，應對印度對AI專業人才的不斷增長的需求。</p>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;">Mirai科技學校在印度通過從學士學位課程的第一學期起融入人工智能，徹底改變了工程教育。學生在專業人士的指導下，參與實際的AI項目，並使用先進的工具和實驗室。畢業生為各個高科技領域的職業做好充分準備，應對印度對AI專業人才的不斷增長的需求。</p>
           <div style="margin-top: 8px;">
             
                   <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">#General</span>

--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -25,8 +25,7 @@
       {% for article in articles %}
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
           <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">{{ article.title }}</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;"><strong>EN:</strong> {{ article.summary_en }}</p>
-          <p style="font-size:14px;line-height:1.6;margin-top:4px;"><strong>ZH:</strong> {{ article.summary_zh }}</p>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary_zh }}</p>
           <div style="margin-top: 8px;">
             {% if article.tags %}
               {% for tag in article.tags %}
@@ -52,8 +51,7 @@
       {% for article in articles %}
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
           <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">{{ article.title }}</a>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;"><strong>EN:</strong> {{ article.summary_en }}</p>
-          <p style="font-size:14px;line-height:1.6;margin-top:4px;"><strong>ZH:</strong> {{ article.summary_zh }}</p>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary_zh }}</p>
           <div style="margin-top: 8px;">
             {% if article.tags %}
               {% for tag in article.tags %}


### PR DESCRIPTION
## Summary
- update summarization prompt to generate only Traditional Chinese summaries
- drop `summary_en` output and usage across the project
- update example JSON data and HTML templates
- regenerate sample digest

## Testing
- `python -m py_compile summarize_articles.py generate_digest.py send_digest.py generate_articles.py`
- `python generate_digest.py`

------
https://chatgpt.com/codex/tasks/task_e_684fbfbbef5c83279f8459e251477251