### PR TITLE
Limit articles fetched per RSS feed

### DIFF
--- a/fetch_rss_articles.py
+++ b/fetch_rss_articles.py
@@ -10,6 +10,9 @@ from bs4 import BeautifulSoup
 CONFIG_FILE = "config/sources.json"
 OUTPUT_FILE = "data/rss_articles.json"
 
+# Limit how many articles to fetch from each RSS feed to avoid long runtimes
+MAX_ARTICLES_PER_FEED = 5
+
 
 def load_sources() -> List[Dict]:
     """Return list of all RSS sources from configuration."""
@@ -74,7 +77,7 @@ def fetch_rss_articles() -> List[Dict]:
         except Exception:
             print(f"\u26a0\ufe0f Failed to parse feed {url}")
             continue
-        for entry in feed.entries:
+        for entry in feed.entries[:MAX_ARTICLES_PER_FEED]:
             title = entry.get("title")
             link = entry.get("link")
             if not title or not link:


### PR DESCRIPTION
## Summary
- add a `MAX_ARTICLES_PER_FEED` constant for limiting RSS items
- restrict parsing loop to first five entries per feed

## Testing
- `python -m py_compile fetch_rss_articles.py`
- `python fetch_rss_articles.py` *(fails: interrupted due to lengthy network requests)*

------
https://chatgpt.com/codex/tasks/task_e_6850d19142208327be37c5a8a22d20f4