### PR TITLE
Remove scoring from fetch scripts

### DIFF
--- a/fetch_newsapi_ai.py
+++ b/fetch_newsapi_ai.py
@@ -4,7 +4,7 @@ from typing import List, Dict
 
 import requests
 from dotenv import load_dotenv
-from utils import load_keywords, keyword_score, source_weight
+from utils import load_keywords, keyword_score
 
 load_dotenv()
 NEWSAPI_AI_KEY = os.getenv("NEWSAPI_AI_KEY")
@@ -50,19 +50,16 @@ def fetch_newsapi_ai_articles() -> List[Dict]:
 
 
 def fetch_and_store() -> List[Dict]:
-    """Fetch raw articles, score them and return the top results."""
+    """Fetch articles that match keywords and store them."""
     articles = fetch_newsapi_ai_articles()
     keywords_cfg = load_keywords()
     all_keywords = [kw for group in keywords_cfg.values() for kw in group]
+    filtered: List[Dict] = []
     for art in articles:
         text = f"{art.get('title', '')} {art.get('content', '')}"
-        art["score"] = (
-            0.5 * len(art.get("content", ""))
-            + 5 * keyword_score(text, all_keywords)
-            + source_weight(art.get("source", {}).get("name", ""))
-        )
-    articles = sorted(articles, key=lambda x: x["score"], reverse=True)[:20]
-    return articles
+        if keyword_score(text, all_keywords) > 0:
+            filtered.append(art)
+    return filtered
 
 
 def main() -> None:

--- a/fetch_rss_articles.py
+++ b/fetch_rss_articles.py
@@ -8,7 +8,7 @@ import aiohttp
 
 import feedparser
 from bs4 import BeautifulSoup
-from utils import load_keywords, keyword_score, source_weight
+from utils import load_keywords, keyword_score
 
 CONFIG_FILE = "config/sources.json"
 OUTPUT_FILE = "data/rss_articles.json"
@@ -124,13 +124,8 @@ async def fetch_rss_articles_async() -> List[Dict]:
     for batch in results:
         for art in batch:
             text = f"{art.get('title', '')} {art.get('content', '')}"
-            art["score"] = (
-                0.5 * len(art.get("content", ""))
-                + 5 * keyword_score(text, all_keywords)
-                + source_weight(art.get("source", {}).get("name", ""))
-            )
-            articles.append(art)
-    articles = sorted(articles, key=lambda x: x["score"], reverse=True)[:20]
+            if keyword_score(text, all_keywords) > 0:
+                articles.append(art)
     return articles
 
 


### PR DESCRIPTION
## Summary
- drop scoring logic from RSS fetching and EventRegistry fetching
- rename `generate_articles.py` to `fetch_newsapi_ai.py`

## Testing
- `python -m py_compile fetch_rss_articles.py fetch_newsapi_ai.py`
- `python fetch_rss_articles.py` *(fails: blocked network requests)*
- `python fetch_newsapi_ai.py` *(fails: missing `NEWSAPI_AI_KEY`)*

------
https://chatgpt.com/codex/tasks/task_e_685103d14aac8327b974d403bdd185fa