### PR TITLE
Add fintech & crypto RSS feeds

### DIFF
--- a/config/sources.json
+++ b/config/sources.json
@@ -103,6 +103,46 @@
       "region": "Asia",
       "topics": ["Finance", "Banking"],
       "full_text": true
+    },
+    {
+      "name": "Fintech Times",
+      "rss_url": "https://thefintechtimes.com/feed",
+      "source_type": "rss",
+      "region": "Global",
+      "topics": ["FinTech", "Finance"],
+      "full_text": true
+    },
+    {
+      "name": "Finance Magnates – FinTech",
+      "rss_url": "https://www.financemagnates.com/fintech/feed/",
+      "source_type": "rss",
+      "region": "Global",
+      "topics": ["FinTech", "Finance"],
+      "full_text": true
+    },
+    {
+      "name": "Cointelegraph",
+      "rss_url": "https://cointelegraph.com/rss",
+      "source_type": "rss",
+      "region": "Global",
+      "topics": ["Blockchain", "Crypto"],
+      "full_text": true
+    },
+    {
+      "name": "Crypto Breaking News",
+      "rss_url": "https://cryptobreaking.com/rss",
+      "source_type": "rss",
+      "region": "Global",
+      "topics": ["Blockchain", "Crypto"],
+      "full_text": true
+    },
+    {
+      "name": "FinanceAsia",
+      "rss_url": "https://www.financeasia.com/rss/latest",
+      "source_type": "rss",
+      "region": "Asia",
+      "topics": ["Finance", "FinTech"],
+      "full_text": true
     }
   ],
   "rsshub_sources": [

--- a/data/source_data.json
+++ b/data/source_data.json
@@ -103,6 +103,46 @@
       "full_text": true,
       "source_type": "rss",
       "rss_url": "https://asianbankingandfinance.net/feed/"
+    },
+    {
+      "name": "Fintech Times",
+      "region": "Global",
+      "topics": ["FinTech", "Finance"],
+      "full_text": true,
+      "source_type": "rss",
+      "rss_url": "https://thefintechtimes.com/feed"
+    },
+    {
+      "name": "Finance Magnates – FinTech",
+      "region": "Global",
+      "topics": ["FinTech", "Finance"],
+      "full_text": true,
+      "source_type": "rss",
+      "rss_url": "https://www.financemagnates.com/fintech/feed/"
+    },
+    {
+      "name": "Cointelegraph",
+      "region": "Global",
+      "topics": ["Blockchain", "Crypto"],
+      "full_text": true,
+      "source_type": "rss",
+      "rss_url": "https://cointelegraph.com/rss"
+    },
+    {
+      "name": "Crypto Breaking News",
+      "region": "Global",
+      "topics": ["Blockchain", "Crypto"],
+      "full_text": true,
+      "source_type": "rss",
+      "rss_url": "https://cryptobreaking.com/rss"
+    },
+    {
+      "name": "FinanceAsia",
+      "region": "Asia",
+      "topics": ["Finance", "FinTech"],
+      "full_text": true,
+      "source_type": "rss",
+      "rss_url": "https://www.financeasia.com/rss/latest"
     }
   ]
 ,


### PR DESCRIPTION
## Summary
- expand RSS sources list with Fintech Times, Finance Magnates, Cointelegraph, Crypto Breaking News and FinanceAsia

## Testing
- `python fetch_rss_articles.py`
- `python generate_digest.py`


------
https://chatgpt.com/codex/tasks/task_e_68510e7c18e08327ad0a5d80d16cae24