### PR TITLE
Fix category display mapping

### DIFF
--- a/generate_digest.py
+++ b/generate_digest.py
@@ -25,9 +25,18 @@ def generate_html(articles):
     global_articles = grouped.get("Global", [])
     east_asian_articles = grouped.get("East Asia", [])
 
+    CATEGORY_DISPLAY_NAME = {
+        "finance_ai": "Applied AI & Fintech",
+        "startup_ai": "General Tech & Startups",
+        "blockchain_ai": "Blockchain & Crypto",
+    }
+
     for article in global_articles + east_asian_articles:
-        if "published_at" not in article:
-            article["published_at"] = article.get("read_time", "")
+        article["published_at"] = article.get("published_at") or article.get("read_time", "1 min read")
+        article["url"] = article.get("url") or "#"
+        article["source"] = article.get("source") or "Unknown"
+        article["tags"] = article.get("tags") or ["General"]
+        article["category_display"] = CATEGORY_DISPLAY_NAME.get(article.get("category", ""), "Unknown Category")
 
     with open(TEMPLATE_FILE, "r", encoding="utf-8") as f:
         template = Template(f.read())

--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -18,7 +18,7 @@
     <!-- 🌍 Global Section -->
     <div style="background-color:#f9f9f6; padding:16px; border-radius:8px; margin-bottom:20px;">
     <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size:24px; margin:0 0 10px 0;">🌍 Global</h2>
-    {% for category, articles in global_articles|groupby('category') %}
+    {% for category, articles in global_articles|groupby('category_display') %}
       <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         {{ icons.get(category, '') }} {{ category }}
       </h2>
@@ -44,7 +44,7 @@
     <!-- 🌏 East Asia Section -->
     <div style="background-color:#f4f4f9; padding:16px; border-radius:8px; margin-bottom:20px;">
     <h2 style="font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size:24px; margin:0 0 10px 0;">🌏 East Asia</h2>
-    {% for category, articles in east_asian_articles|groupby('category') %}
+    {% for category, articles in east_asian_articles|groupby('category_display') %}
       <h2 style="font-size: 18px; font-weight: 600; margin-top: 40px; font-family:'Playfair Display', Georgia, 'Times New Roman', serif;">
         {{ icons.get(category, '') }} {{ category }}
       </h2>


### PR DESCRIPTION
## Summary
- ensure news categories map to display names and icons
- group articles by the new `category_display`

## Testing
- `python -m py_compile *.py`
- `python generate_digest.py`

------
https://chatgpt.com/codex/tasks/task_e_6852229280f88327924e1a4863f79e67