### PR TITLE
Fix None source/read_time

### DIFF
--- a/generate_digest.py
+++ b/generate_digest.py
@@ -1,4 +1,5 @@
 import json
+import math
 from datetime import datetime
 from jinja2 import Template
 
@@ -56,10 +57,19 @@ def generate_html(articles):
         # Log the raw category for debugging
         print("Category:", article.get("category"))
 
+        src = article.get("source")
+        if isinstance(src, dict):
+            src = src.get("name")
+        article["source"] = src or "Unknown Source"
+
+        if not article.get("read_time"):
+            content = article.get("content", "")
+            word_count = len(content.split())
+            article["read_time"] = f"{max(1, math.ceil(word_count / 200))} min read"
+
         article["published_at"] = article.get(
             "published_at") or article.get("read_time", "1 min read")
         article["url"] = article.get("url") or "#"
-        article["source"] = article.get("source") or "Unknown"
         article["tags"] = article.get("tags") or ["General"]
 
         cat_key = normalize(article.get("category", ""))

--- a/summarize_articles.py
+++ b/summarize_articles.py
@@ -1,5 +1,6 @@
 import json
 import os
+import math
 from typing import Dict, List, Tuple
 
 import openai
@@ -101,13 +102,21 @@ def main() -> None:
         print("🈶 Summary:", summary_zh)
         print("-----")
 
+        src = art.get('source')
+        if isinstance(src, dict):
+            src = src.get('name')
+        source_name = src or 'Unknown Source'
+
+        word_count = len(body.split())
+        read_time_min = max(1, math.ceil(word_count / 200))
+
         summarized.append({
             'region': region,
             'category': category,
             'title': title,
             'summary_zh': summary_zh,
-            'source': art.get('source', {}).get('name'),
-            'read_time': '1 min read',
+            'source': source_name,
+            'read_time': f"{read_time_min} min read",
             'url': art.get('url'),
             'tags': []
         })


### PR DESCRIPTION
## Summary
- compute reading time during summarization
- normalize source name in summarization and digest generation
- fall back to computed reading time if missing

## Testing
- `python -m py_compile summarize_articles.py generate_digest.py`

------
https://chatgpt.com/codex/tasks/task_e_68522ccfe36883278bb98fe83fe5051a