### PR TITLE
Add run_all script for full pipeline coordination

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import subprocess
+from datetime import datetime
+
+
+STEPS = [
+    ("fetch_newsapi_ai.py", "data/newsapi_ai_articles.json"),
+    ("fetch_rss_articles.py", "data/rss_articles.json"),
+    ("filter_articles_by_date.py", "data/recent_articles.json"),
+    ("filter_with_gpt.py", "data/classified_articles.json"),
+    ("select_top_articles.py", "data/selected_articles.json"),
+    ("summarize_articles.py", "data/news_data.json"),
+    ("validate_news_data.py", "data/news_data.json"),
+    ("generate_digest.py", "digest.html"),
+    ("send_digest.py", None),
+]
+
+
+def check_output_file(path: str) -> None:
+    if not path:
+        return
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        print(f"⚠️ Warning: {path} is missing or empty")
+
+
+def run_step(index: int, script: str, output: str | None) -> None:
+    print(f"🔧 [Step {index}] Running {script}...")
+    try:
+        result = subprocess.run([sys.executable, script], check=True)
+        if result.returncode == 0:
+            print(f"✅ [Step {index}] {script} completed")
+        else:
+            print(
+                f"❌ [Step {index}] {script} exited with code {result.returncode}"
+            )
+    except subprocess.CalledProcessError as exc:
+        print(f"❌ [Step {index}] {script} failed: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"❌ [Step {index}] {script} error: {exc}")
+    finally:
+        check_output_file(output)
+
+
+def main() -> None:
+    start = datetime.now().strftime("%Y-%m-%d %H:%M")
+    print(f"⏰ Starting Polaris Digest Run: {start}")
+    for i, (script, output) in enumerate(STEPS, start=1):
+        run_step(i, script, output)
+    end = datetime.now().strftime("%Y-%m-%d %H:%M")
+    print(f"⏰ Polaris Digest Run finished: {end}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_all.py` to sequentially execute the news pipeline
- log success/failure of each stage and warn about missing outputs

## Testing
- `python -m py_compile run_all.py`
- `python run_all.py` *(fails: Missing API keys)*

------
https://chatgpt.com/codex/tasks/task_e_68523c42935c83278f72d4f705f51499