### PR TITLE
Restore and improve keyword scoring

### DIFF
--- a/config/keywords.json
+++ b/config/keywords.json
@@ -1,23 +1,15 @@
 {
   "keywords": [
-    "AI in banking", "金融 AI", "AI-powered trading", "AI 交易", "Algorithmic trading", "演算法交易",
-    "Robo-advisor", "機器人理財", "Fraud detection", "詐欺偵測", "Risk assessment", "風險評估",
-    "Credit scoring", "信用評分", "Automated underwriting", "自動核保", "Financial forecasting", "財務預測",
-    "Sentiment analysis", "情緒分析", "Chatbot", "金融客服機器人", "AML", "反洗錢", "KYC", "客戶審查",
-    "Predictive analytics", "預測分析", "Portfolio optimization", "組合優化", "Generative AI in finance", "生成式 AI 金融",
-    "AI-driven asset management", "AI 資產管理", "AI-based compliance", "AI 合規管理", "AI risk models", "AI 風險模型",
-    "AI-powered customer service", "AI 客服",
-
-    "AI startup", "AI 新創", "AI-driven innovation", "AI 創新", "AI-powered platform", "AI 平台",
-    "AI accelerator", "AI 加速器", "Generative AI company", "生成式 AI 公司", "LLM startup", "大型語言模型新創",
-    "AI entrepreneurship", "AI 創業", "AI funding", "AI 融資", "AI venture capital", "AI 創投",
-    "AI product launch", "AI 產品發表", "AI ecosystem", "AI 生態系", "AI SaaS", "AI 軟體即服務",
-    "AI-powered SaaS", "AI 雲端服務", "AI talent", "AI 人才", "AI disruption", "AI 顛覆",
-
-    "Blockchain AI", "區塊鏈 AI", "Crypto AI", "加密貨幣 AI", "AI-powered crypto trading", "AI 加密貨幣交易",
-    "DeFi AI", "去中心化金融 AI", "AI in DeFi", "AI 應用於 DeFi", "Smart contract AI", "智能合約 AI",
-    "AI blockchain integration", "AI 區塊鏈整合", "AI-driven NFT", "AI NFT", "AI for crypto compliance", "AI 加密合規",
-    "Crypto fraud detection", "加密詐欺偵測", "AI in digital assets", "AI 數位資產", "AI-powered mining", "AI 礦業",
-    "AI tokenization", "AI 代幣化", "CBDC AI", "數位貨幣 AI", "AI crypto analytics", "AI 加密分析"
+    "AI", "ai", "人工智能", "人工智慧", "machine learning", "deep learning",
+    "智能風控", "智能客服", "AI風控", "AI客服", "AI保險", "AI投資",
+    "智能投資", "算法交易", "algo trading", "AI wealth", "智能理財",
+    "AI lending", "AI loan", "AI信用", "智能信貸",
+    "AI startup", "AI初創", "AI新創", "生成式AI", "GenAI",
+    "AI product", "AI solution", "AI平台", "AI-as-a-Service", "SaaS AI",
+    "生成模型", "ChatGPT", "大語言模型", "LLM startup",
+    "Blockchain", "區塊鏈", "智能合約", "smart contract", "加密貨幣",
+    "crypto", "DeFi", "Web3", "去中心化", "比特幣", "Bitcoin",
+    "以太坊", "Ethereum", "stablecoin", "crypto exchange",
+    "crypto trading", "crypto lending", "blockchain應用", "區塊鏈技術"
   ]
 }

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import List
 
 
@@ -9,9 +10,19 @@ def load_keywords():
 
 
 def keyword_score(article_text: str, keywords: List[str]) -> int:
-    """Return how many keywords appear in the given text (case-insensitive)."""
+    """Return the total number of keyword hits in ``article_text``."""
+
     lowered = article_text.lower()
-    return sum(1 for kw in keywords if kw.lower() in lowered)
+    score = 0
+    for kw in keywords:
+        kw_lower = kw.lower()
+        # English keywords use word boundaries but allow hyphenated forms
+        if re.search(r"[a-zA-Z0-9]", kw_lower):
+            pattern = rf"\b{re.escape(kw_lower)}(?!\w)"
+        else:
+            pattern = re.escape(kw_lower)
+        score += len(re.findall(pattern, lowered))
+    return score
 
 
 def source_weight(source_name: str) -> int:


### PR DESCRIPTION
## Summary
- restore `keyword_score` with regex matching and partial word support
- update keyword list for broader AI and blockchain coverage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68527d600f4083279c28b54780f802a2