### PR TITLE
Remove unused tags from digest cards

### DIFF
--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -26,15 +26,7 @@
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
           <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">{{ article.title }}</a>
           <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary_zh }}</p>
-          <div style="margin-top: 8px;">
-            {% if article.tags %}
-              {% for tag in article.tags %}
-                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
-              {% endfor %}
-            {% else %}
-                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">#General</span>
-            {% endif %}
-          </div>
+          {# Removed tags display #}
           <div style="font-size:12px;color:#999;margin-top:6px;">{{ article.source }} · {{ article.read_time }}</div>
         </div>
       {% endfor %}
@@ -52,15 +44,7 @@
         <div style="margin-bottom: 36px; background: #f9f9f9; border-radius: 12px; padding: 20px;">
           <a href="{{ article.url }}" style="color: #000000; text-decoration: none; font-family:'Playfair Display', Georgia, 'Times New Roman', serif; font-weight:600; font-size: 16px;">{{ article.title }}</a>
           <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary_zh }}</p>
-          <div style="margin-top: 8px;">
-            {% if article.tags %}
-              {% for tag in article.tags %}
-                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">{{ tag }}</span>
-              {% endfor %}
-            {% else %}
-                  <span style="display: inline-block; background: #eaeaea; color: #333; font-size: 11px; font-weight:400; padding: 4px 10px; border-radius: 999px; margin-right: 6px;">#General</span>
-            {% endif %}
-          </div>
+          {# Removed tags display #}
           <div style="font-size:12px;color:#999;margin-top:6px;">{{ article.source }} · {{ article.read_time }}</div>
         </div>
       {% endfor %}


### PR DESCRIPTION
## Summary
- remove tag display from `digest_single_column.html`

## Testing
- `pytest -q`
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_6853d18d41cc8327be0771f47f2086eb