### PR TITLE
Improve article title styling

### DIFF
--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -21,9 +21,9 @@
     }
     .article-title {
       font-family: 'Playfair Display', serif;
-      color: #800020;
-      font-size: 18px;
-      font-weight: 700;
+      color: #660017; /* slightly darker shade */
+      font-size: 20px; /* bigger */
+      font-weight: 800; /* thicker */
       margin: 12px 0 6px 0;
       line-height: 1.4;
     }


### PR DESCRIPTION
## Summary
- darken and enlarge article titles in the daily digest template

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 test.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6853d70a42788327bc7be3e9fc8cd0c3