### PR TITLE
Update classification names and file paths

### DIFF
--- a/select_top_articles.py
+++ b/select_top_articles.py
@@ -6,12 +6,12 @@ CATEGORY_DIR = "data/categorized"
 OUTPUT_FILE = "data/selected_articles.json"
 
 FILES = [
-    "global_startup_ai.json",
-    "global_finance_ai.json",
-    "global_blockchain_ai.json",
-    "east asia_startup_ai.json",
-    "east asia_finance_ai.json",
-    "east asia_blockchain_ai.json",
+    "global_General Tech & Startups.json",
+    "global_Applied AI & FinTech.json",
+    "global_Blockchain & Crypto.json",
+    "east asia_General Tech & Startups.json",
+    "east asia_Applied AI & FinTech.json",
+    "east asia_Blockchain & Crypto.json",
 ]
 
 def load_json(path: str) -> List[Dict]:


### PR DESCRIPTION
## Summary
- update classify_articles_gpt to request human readable `category` and `region`
- parse the new response format and save grouped results using readable names
- adjust categorized file names in select_top_articles

## Testing
- `python -m py_compile classify_articles_gpt.py select_top_articles.py`

------
https://chatgpt.com/codex/tasks/task_e_68551879cda883279af61c8e07375865