### PR TITLE
Use Gemma model for article classification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ openai
 feedparser
 beautifulsoup4
 aiohttp
-tiktoken


### PR DESCRIPTION
## Summary
- replace OpenAI calls in `classify_articles_gpt.py` with HTTP calls to the local Gemma endpoint
- simplify token truncation and parsing logic
- remove unused `tiktoken` dependency

## Testing
- `python -m py_compile classify_articles_gpt.py`
- `python classify_articles_gpt.py`

------
https://chatgpt.com/codex/tasks/task_e_6858c5d363808327b61e3b9695207124