### PR TITLE
Add logging for article counts

### DIFF
--- a/classify_articles_gpt.py
+++ b/classify_articles_gpt.py
@@ -197,6 +197,7 @@ async def main_async() -> None:
     print(
         f"Wrote {len(results)} articles with classifications to {OUTPUT_ALL_FILE}"
     )
+    print(f"\U0001F3F7\FE0F \u6210\u529F\u5206\u985E\u7684\u6587\u7AE0\u6578\u91CF: {len(results)}")
 
 
 if __name__ == "__main__":

--- a/fetch_newsapi_ai.py
+++ b/fetch_newsapi_ai.py
@@ -69,6 +69,7 @@ def main() -> None:
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         json.dump(articles, f, ensure_ascii=False, indent=2)
     print(f"Wrote {OUTPUT_FILE}")
+    print(f"\U0001F4E5 NewsAPI \u6587\u7AE0\u6578\u91CF: {len(articles)}")
 
 
 if __name__ == "__main__":

--- a/fetch_rss_articles.py
+++ b/fetch_rss_articles.py
@@ -156,6 +156,7 @@ async def main_async() -> None:
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         json.dump(articles, f, ensure_ascii=False, indent=2)
     print(f"Wrote {len(articles)} articles to {OUTPUT_FILE}")
+    print(f"\U0001F4E5 RSS \u6587\u7AE0\u6578\u91CF: {len(articles)}")
 
 
 if __name__ == "__main__":

--- a/filter_articles_by_date.py
+++ b/filter_articles_by_date.py
@@ -57,6 +57,8 @@ def main() -> None:
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         json.dump(recent, f, ensure_ascii=False, indent=2)
     print(f"Wrote {len(recent)} articles to {OUTPUT_FILE}")
+    filtered = recent
+    print(f"\U0001F4C5 \u4FDD\u7559\u7684\u6700\u65B0\u6587\u7AE0\u6578\u91CF: {len(filtered)}")
 
 
 if __name__ == "__main__":

--- a/filter_relevance_gpt.py
+++ b/filter_relevance_gpt.py
@@ -124,6 +124,8 @@ async def main_async() -> None:
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         json.dump(results, f, ensure_ascii=False, indent=2)
     print(f"✅ Wrote {len(results)} relevant articles to {OUTPUT_FILE}")
+    relevant_articles = results
+    print(f"\U0001F9E0 GPT \u5224\u5B9A\u70BA\u76F8\u95DC\u7684\u6587\u7AE0\u6578\u91CF: {len(relevant_articles)}")
 
 if __name__ == "__main__":
     asyncio.run(main_async())

--- a/select_top_articles.py
+++ b/select_top_articles.py
@@ -57,6 +57,7 @@ def main() -> None:
         json.dump(selected, f, ensure_ascii=False, indent=2)
 
     print(f"Wrote {len(selected)} articles to {OUTPUT_FILE}")
+    print(f"\u2b50 \u6bcf\u985e\u7cbe\u9078\u6587\u7ae0\u7e3d\u6578: {len(selected)}")
 
 
 if __name__ == "__main__":

--- a/summarize_articles.py
+++ b/summarize_articles.py
@@ -141,6 +141,7 @@ async def main_async() -> None:
         json.dump(summarized, f, ensure_ascii=False, indent=2)
 
     print(f"✅ Wrote summaries to {OUTPUT_FILE}")
+    print(f"\U0001F4DD \u6210\u529F\u6458\u8981\u7684\u6587\u7AE0\u7E3D\u6578: {len(summarized)}")
 
 
 if __name__ == '__main__':

--- a/validate_news_data.py
+++ b/validate_news_data.py
@@ -86,6 +86,8 @@ def main() -> None:
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         json.dump(articles, f, ensure_ascii=False, indent=2)
     print(f"Validated {len(articles)} articles and wrote to {OUTPUT_FILE}")
+    validated = articles
+    print(f"\u2705 \u9a57\u8b49\u5f8c\u4fdd\u7559\u7684\u6709\u6548\u65b0\u805e\u6578\u91CF: {len(validated)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add news article count logs after each major processing step

## Testing
- `python -m py_compile fetch_newsapi_ai.py fetch_rss_articles.py filter_articles_by_date.py filter_relevance_gpt.py classify_articles_gpt.py select_top_articles.py summarize_articles.py validate_news_data.py`


------
https://chatgpt.com/codex/tasks/task_e_6858f04fa18c8327994a0f5a8383f42d