### PR TITLE
Add OpenAI fallback scripts

### DIFF
--- a/classify_articles_openai.py
+++ b/classify_articles_openai.py
@@ -1,0 +1,191 @@
+"""OpenAI-based article classifier.
+
+This runs after ``filter_relevance_openai.py`` and assigns a category
+and region to each article. The results are saved for later summarization.
+"""
+
+import json
+import os
+import re
+import asyncio
+from typing import Dict, List, Any
+
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+INPUT_FILE = "data/classified_articles_openai.json"
+OUTPUT_ALL_FILE = "data/news_data_openai.json"
+CATEGORY_DIR = "data/categorized"
+MODEL_NAME = "gpt-3.5-turbo"
+
+CATEGORIES = [
+    "General Tech & Startups",
+    "Applied AI & FinTech",
+    "Blockchain & Crypto",
+]
+
+REGIONS = ["Global", "East Asia"]
+MAX_CONTENT_TOKENS = 1000
+
+
+def truncate_text(text: str, max_tokens: int = MAX_CONTENT_TOKENS) -> str:
+    words = text.split()
+    return " ".join(words[:max_tokens])
+
+
+PROMPT_TEMPLATE = """
+You are a news classification AI assistant working for the AI Innovation Department at TPIsoftware, a Taiwan-based software company specializing in artificial intelligence, financial technology, and enterprise software solutions.
+
+Our team is building an internal news intelligence system to help product managers, researchers, and engineers stay updated on real-world applications of AI and emerging technologies across global and East Asian markets.
+
+Your task is to analyze each article and assign:
+1. One **category** — the article’s primary topic
+2. One **region** — where the article is geographically focused
+
+---
+
+🎯 Why this matters:
+Your classifications help us:
+- Identify real-world use cases of AI and FinTech
+- Track innovation across Asia and the world
+- Surface relevant news for internal strategy, product planning, and technical research
+
+---
+
+🧠 **Categories (choose one only):**
+
+- **General Tech & Startups**
+  For news about general technology trends, enterprise tools, consumer apps, or startup activity not directly focused on AI, finance, or crypto.
+  *Example: A startup launches a productivity tool or a SaaS company raises funding.*
+
+- **Applied AI & FinTech**
+  For articles about practical uses of artificial intelligence or financial technology. Includes LLM applications, algorithmic trading, AI customer service, robo-advisors, fraud detection, etc.
+  *Example: A bank uses a large language model to automate customer service.*
+
+- **Blockchain & Crypto**
+  For content about crypto exchanges, smart contracts, Web3 infrastructure, blockchain applications in finance, or CBDCs.
+  *Example: A government announces a pilot program for a digital currency.*
+
+---
+
+🌍 **Regions (choose one only):**
+
+- **East Asia**
+  For news focused on Taiwan, China, Japan, South Korea, or Hong Kong.
+  *This region is our strategic priority and we track its trends closely.*
+
+- **Global**
+  For all other regions (e.g. U.S., Europe, India), or if the article discusses global tech trends, multinational initiatives, or broad international applications.
+
+---
+
+📤 **Output Format:**
+
+Return only a JSON object on a single line, with no formatting or explanation:
+{"category": "Applied AI & FinTech", "region": "East Asia"}
+"""
+
+
+def load_articles(path: str) -> List[Dict[str, Any]]:
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            raise RuntimeError(f"Invalid JSON in {path}")
+
+
+semaphore = asyncio.Semaphore(3)
+
+
+def _parse_response(text: str) -> Dict[str, Any]:
+    try:
+        match = re.search(r"\{[^{}]*\}", text, re.DOTALL)
+        if match:
+            text = match.group(0)
+        else:
+            text = text.replace("```json", "").replace("```", "").strip()
+        data = json.loads(text)
+        return {
+            "category": data.get("category", ""),
+            "region": data.get("region", "Global"),
+        }
+    except Exception as exc:
+        print("⚠️ Failed to parse model response:", exc)
+        print("🧪 Raw text was:", repr(text))
+        return {"category": "", "region": "Global"}
+
+
+async def classify_article(article: Dict[str, Any]) -> Dict[str, Any] | None:
+    title = article.get("title", "")
+    content = article.get("content") or article.get("description", "")
+    if not title or not content:
+        return None
+    short_content = truncate_text(content)
+    prompt = f"{PROMPT_TEMPLATE.strip()}\n\nTitle: {title}\n\nArticle Content:\n{short_content}"
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a JSON-only API that assigns a category and region to the article.",
+        },
+        {"role": "user", "content": prompt},
+    ]
+    async with semaphore:
+        try:
+            resp = await openai.ChatCompletion.acreate(
+                model=MODEL_NAME,
+                messages=messages,
+                temperature=0.1,
+            )
+            text = resp.choices[0].message.content
+            print("📩 Model raw response:", text)
+            return _parse_response(text)
+        except Exception as exc:
+            print(f"❌ OpenAI request failed: {exc}")
+            return None
+
+
+async def main_async() -> None:
+    articles = load_articles(INPUT_FILE)
+    os.makedirs(CATEGORY_DIR, exist_ok=True)
+
+    grouped = {region: {cat: [] for cat in CATEGORIES} for region in REGIONS}
+    results: List[Dict[str, Any]] = []
+
+    valid_articles = [a for a in articles if a.get("title") and (a.get("content") or a.get("description"))]
+
+    tasks = [classify_article(a) for a in valid_articles]
+    responses = await asyncio.gather(*tasks)
+
+    for art, result in zip(valid_articles, responses):
+        if not result:
+            continue
+        art["category"] = result.get("category", "")
+        art["region"] = result.get("region", "Global")
+        results.append(art)
+        cat = art["category"]
+        region = art["region"]
+        if region in grouped and cat in grouped[region]:
+            grouped[region][cat].append(art)
+
+    with open(OUTPUT_ALL_FILE, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+    for region, cats in grouped.items():
+        for cat, items in cats.items():
+            safe_cat = cat.lower().replace(" ", "_").replace("&", "and")
+            filename = f"{region.lower()}_{safe_cat}.json"
+            path = os.path.join(CATEGORY_DIR, filename)
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(items, f, ensure_ascii=False, indent=2)
+    print(
+        f"Wrote {len(results)} articles with classifications to {OUTPUT_ALL_FILE}"
+    )
+    print(f"🏷️ OpenAI 成功分類的文章數量: {len(results)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main_async())

--- a/filter_relevance_openai.py
+++ b/filter_relevance_openai.py
@@ -1,0 +1,124 @@
+import json
+import os
+import asyncio
+import re
+from typing import Any, Dict, List
+
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+INPUT_FILE = "data/recent_articles.json"
+OUTPUT_FILE = "data/classified_articles_openai.json"
+MODEL_NAME = "gpt-3.5-turbo"
+MAX_CONTENT_TOKENS = 1000
+
+PROMPT_TEMPLATE = """
+You are an AI-powered news filter working at TPIsoftware, a software company based in Taiwan that specializes in AI development, enterprise platforms, and financial technologies.
+
+Each day, your job is to help the product and strategy teams scan hundreds of global and East Asian news articles and identify only the ones that are relevant to our company’s interests.
+
+We are specifically interested in news articles related to:
+
+- Artificial Intelligence (AI), including new applications, tools, models, or platforms.
+- Financial Technology (FinTech), such as digital banking, fraud detection, robo-advisors, AI in risk control or personal finance.
+- Blockchain and Crypto technologies, especially their use in automation, intelligent agents, or AI-enhanced Web3 projects.
+
+We **do not want** articles that are mainly about politics, lifestyle, sports, culture, general economy, or unrelated industries.
+
+Please focus on whether the article has any real or potential connection to **AI, FinTech, or Blockchain innovation**, especially if it has product, funding, technical, or strategic value.
+
+Respond with a single JSON object like this:
+{ "keep": true }
+or
+{ "keep": false }
+"""
+
+
+def truncate_text(text: str, max_tokens: int = MAX_CONTENT_TOKENS) -> str:
+    words = text.split()
+    return " ".join(words[:max_tokens])
+
+
+def load_articles(path: str) -> List[Dict[str, Any]]:
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            raise RuntimeError(f"Invalid JSON in {path}")
+
+
+def _parse_response(text: str) -> bool:
+    try:
+        match = re.search(r"\{[^{}]*\}", text, re.DOTALL)
+        if match:
+            text = match.group(0)
+        else:
+            text = text.replace("```json", "").replace("```", "").strip()
+        data = json.loads(text)
+        return data.get("keep", False)
+    except Exception as exc:
+        print("⚠️ Failed to parse model response:", exc)
+        print("🧪 Raw text was:", repr(text))
+        return False
+
+
+semaphore = asyncio.Semaphore(3)
+
+
+async def check_relevance(article: Dict[str, Any]) -> bool | None:
+    title = article.get("title", "")
+    content = article.get("content") or article.get("description", "")
+    if not title or not content:
+        return None
+    short_content = truncate_text(content)
+    prompt = f"{PROMPT_TEMPLATE.strip()}\n\nTitle: {title}\n\nArticle Content:\n{short_content}"
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a JSON-only API that determines if an article is relevant to AI, FinTech, or Blockchain.",
+        },
+        {"role": "user", "content": prompt},
+    ]
+    async with semaphore:
+        try:
+            resp = await openai.ChatCompletion.acreate(
+                model=MODEL_NAME,
+                messages=messages,
+                temperature=0.1,
+            )
+            text = resp.choices[0].message.content
+            print("📩 Model raw response:", text)
+            return _parse_response(text)
+        except Exception as exc:
+            print(f"❌ OpenAI request failed: {exc}")
+            return None
+
+
+async def main_async() -> None:
+    articles = load_articles(INPUT_FILE)
+    valid_articles = [a for a in articles if a.get("title") and (a.get("content") or a.get("description"))]
+    results: List[Dict[str, Any]] = []
+
+    tasks = [check_relevance(a) for a in valid_articles]
+    responses = await asyncio.gather(*tasks)
+
+    for art, keep in zip(valid_articles, responses):
+        if keep:
+            results.append(art)
+        elif keep is None:
+            print(f"⚠️ Skipped article due to LLM error: {art['title']}")
+
+    os.makedirs("data", exist_ok=True)
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+    print(f"✅ Wrote {len(results)} relevant articles to {OUTPUT_FILE}")
+    print(f"🧠 OpenAI 判定為相關的文章數量: {len(results)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main_async())

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 feedparser
 beautifulsoup4
 aiohttp
+openai

--- a/summarize_articles_openai.py
+++ b/summarize_articles_openai.py
@@ -1,0 +1,139 @@
+import json
+import os
+import math
+from typing import Dict, List
+import logging
+import asyncio
+
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+logging.basicConfig(level=logging.ERROR)
+
+INPUT_FILE = "data/news_data_openai.json"
+OUTPUT_FILE = "data/news_data_openai.json"
+MODEL_NAME = "gpt-3.5-turbo"
+
+
+def load_articles() -> List[Dict]:
+    if not os.path.exists(INPUT_FILE):
+        return []
+    with open(INPUT_FILE, "r", encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            raise RuntimeError(f"Invalid JSON in {INPUT_FILE}")
+
+
+semaphore = asyncio.Semaphore(3)
+
+
+def _parse_summary(text: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("Summary:"):
+            return line.replace("Summary:", "").strip()
+    return text.strip()
+
+
+async def openai_summarize(title: str, body: str) -> str:
+    prompt = f"""
+You are a bilingual AI assistant working for TPIsoftware, a Taiwan-based company specializing in enterprise platforms, AI development, and financial technologies.
+
+Your task is to help internal teams — including product managers, developers, and data scientists — quickly understand news articles related to AI, FinTech, and emerging technology. Your summaries will appear in our internal daily news digest.
+
+You will be given full-text news articles in either English or Chinese.
+
+## Your Goals:
+1. Summarize the article in **Traditional Chinese**, using up to **4 concise sentences**.
+2. Be accurate — do **not invent** or infer information not in the original article.
+3. Keep important **technical terms**, and include the **English term in parentheses** if needed.
+4. Avoid generic phrases like "the company" or "the startup" — use specific names and dates when available.
+
+## Input
+**Title**:
+{title}
+
+**Article Content**:
+{body}
+
+## Output (in the following format):
+---
+Summary: [Your Traditional Chinese summary here]
+"""
+    messages = [
+        {
+            "role": "system",
+            "content": "Return only a short summary in Traditional Chinese.",
+        },
+        {"role": "user", "content": prompt},
+    ]
+    async with semaphore:
+        try:
+            resp = await openai.ChatCompletion.acreate(
+                model=MODEL_NAME,
+                messages=messages,
+                temperature=0.1,
+            )
+            text = resp.choices[0].message.content
+            print("📩 Model raw response:", text)
+            return _parse_summary(text)
+        except Exception as exc:
+            logging.error("OpenAI API call failed: %s", exc)
+            return ""
+
+
+async def main_async() -> None:
+    articles = load_articles()
+    summarized = []
+
+    valid_articles = [a for a in articles if a.get('title') and a.get('content')]
+
+    tasks = [openai_summarize(a['title'], a['content']) for a in valid_articles]
+    summaries = await asyncio.gather(*tasks)
+
+    for art, summary_zh in zip(valid_articles, summaries):
+        if not summary_zh:
+            continue
+
+        region = art.get('region') or "Global"
+        category = art.get('category') or "General Tech & Startups"
+
+        print("✅ Title:", art['title'])
+        print("📝 Category:", category)
+        print("🈶 Summary:", summary_zh)
+        print("-----")
+
+        src = art.get('source')
+        if isinstance(src, dict):
+            src = src.get('name')
+        source_name = src or 'Unknown Source'
+
+        published = art.get('publishedAt') or art.get('published_at')
+
+        word_count = len(art['content'].split())
+        read_time_min = max(1, math.ceil(word_count / 200))
+
+        summarized.append({
+            'region': region,
+            'category': category,
+            'title': art['title'],
+            'summary_zh': summary_zh,
+            'source': source_name,
+            'read_time': f"{read_time_min} min read",
+            'url': art.get('url'),
+            'published_at': published,
+            'tags': []
+        })
+
+    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+        json.dump(summarized, f, ensure_ascii=False, indent=2)
+
+    print(f"✅ Wrote summaries to {OUTPUT_FILE}")
+    print(f"📝 OpenAI 成功摘要的文章總數: {len(summarized)}")
+
+
+if __name__ == '__main__':
+    asyncio.run(main_async())


### PR DESCRIPTION
## Summary
- implement OpenAI-based versions of relevance filtering, classification and summarization
- add `openai` library requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859068ba3c08327b2b96bd26e7963a1