### PR TITLE
Fix send_to_line TextComponent import error

### DIFF
--- a/send_to_line.py
+++ b/send_to_line.py
@@ -10,7 +10,6 @@ from linebot.v3.messaging.models import (
     FlexCarousel,
     FlexMessage,
     PushMessageRequest,
-    TextComponent,
 )
 
 # Load environment variables


### PR DESCRIPTION
## Summary
- remove nonexistent `TextComponent` from LINE messaging imports

## Testing
- `python -m py_compile send_to_line.py`
- `python send_to_line.py` *(fails: LINE_CHANNEL_ACCESS_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_685a1884aa8c8327913a5f56a074ca89