### PR TITLE
Fix empty summary issue in LINE push

### DIFF
--- a/send_to_line.py
+++ b/send_to_line.py
@@ -73,7 +73,11 @@ def build_bubble(article: dict) -> FlexBubble:
                 },
                 {
                     "type": "text",
-                    "text": article.get("summary") or article.get("summary_zh", ""),
+                    "text": (
+                        article.get("summary")
+                        or article.get("summary_zh")
+                        or "No summary available."
+                    ),
                     "size": "sm",
                     "color": "#666666",
                     "wrap": True,


### PR DESCRIPTION
## Summary
- prevent empty summary text in LINE push messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a19bbd4dc8327bb1e6a597bbb1dae