### PR TITLE
Add RSS fetch count logging

### DIFF
--- a/logs/fetch_counts.json
+++ b/logs/fetch_counts.json
@@ -1,0 +1,14 @@
+{
+  "TechCrunch": 0,
+  "TechNode (動點科技)": 0,
+  "TechNews (台灣)": 0,
+  "Decrypt": 0,
+  "The Next Web (TNW)": 0,
+  "Ubergizmo": 0,
+  "Recode": 0,
+  "CryptoSlate": 0,
+  "Fintech Times": 0,
+  "Finance Magnates – FinTech": 0,
+  "Cointelegraph": 0,
+  "FinanceAsia": 0
+}


### PR DESCRIPTION
## Summary
- display how many articles were fetched from each RSS source
- save per-source counts to `logs/fetch_counts.json`
- report missing `rss_url` and fetch failures without stopping execution

## Testing
- `pytest -q`
- `python fetch_rss_articles.py` *(fails to fetch due to network, but shows counts)*

------
https://chatgpt.com/codex/tasks/task_e_685a40da4ac88327aea39a782d9bbd9e