### PR TITLE
Update GPT relevance scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This executes the following steps:
 1. `fetch_newsapi_ai.py` — Query EventRegistry for AI/FinTech articles.
 2. `fetch_rss_articles.py` — Async fetch from RSS/RSSHub sources using `config/sources.json`.
 3. `filter_articles_by_date.py` — Keep articles published in the last two days.
-4. `filter_relevance_gpt.py` — Remove unrelated articles and assign a relevance score.
+4. `filter_relevance_gpt.py` — Use GPT to decide if an article should be kept and assign a 0–10 relevance score.
 5. `classify_articles_gpt.py` — Categorize and tag the region.
 6. `select_top_articles.py` — Pick top article per category and region.
 7. `summarize_articles.py` — Generate Traditional Chinese summaries.


### PR DESCRIPTION
## Summary
- refine README to note GPT scoring criteria
- expand GPT prompt for relevance filtering with scoring rubric
- parse `score` from the LLM response and combine with keyword weight

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a5ec7ff548327a1565a4914a938f2