### PR TITLE
Fix summary text color

### DIFF
--- a/templates/digest_single_column.html
+++ b/templates/digest_single_column.html
@@ -56,7 +56,7 @@
           <h3 class="article-title">
             <a href="{{ article.url }}" style="color: inherit; text-decoration: none;">{{ article.title }}</a>
           </h3>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary_zh }}</p>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;color:#000000;">{{ article.summary_zh }}</p>
           {# Removed tags display #}
           <div style="font-size:12px;color:#999;margin-top:6px;">{{ article.source }} · {{ article.read_time }}</div>
         </div>
@@ -76,7 +76,7 @@
           <h3 class="article-title">
             <a href="{{ article.url }}" style="color: inherit; text-decoration: none;">{{ article.title }}</a>
           </h3>
-          <p style="font-size:14px;line-height:1.6;margin-top:10px;">{{ article.summary_zh }}</p>
+          <p style="font-size:14px;line-height:1.6;margin-top:10px;color:#000000;">{{ article.summary_zh }}</p>
           {# Removed tags display #}
           <div style="font-size:12px;color:#999;margin-top:6px;">{{ article.source }} · {{ article.read_time }}</div>
         </div>


### PR DESCRIPTION
## Summary
- enforce black color on article summaries in email template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python generate_digest.py`

------
https://chatgpt.com/codex/tasks/task_e_685e07b21b008327904a1e017cc3322e