### PR TITLE
Switch to Gemini API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ feedparser
 beautifulsoup4
 aiohttp
 line-bot-sdk==3.*
+google-generativeai


### PR DESCRIPTION
## Summary
- swap local model calls for Gemini API
- configure GenerativeModel instances with GEMINI_API_KEY
- update relevance, classification, and summarization logic
- add `google-generativeai` to requirements

## Testing
- `python -m py_compile filter_relevance_gpt.py classify_articles_gpt.py summarize_articles.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6865fdd8892c83278410663bf724f1bf